### PR TITLE
Add deploy to render support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ STRIPE_SECRET_KEY="sk_test_..."
 # It has the `NEXT_PUBLIC_` prefix so that it can be used in the client-side code
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 # The URL that will be redirected to after a user completes Connect Onboarding
-DEMO_HOST="http://localhost:3000"
+CONNECT_ONBOARDING_REDIRECT_URL="http://localhost:3000"
 
 ### Auth configuration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-## Example Stripe Issuing and Treasury integration demonstrating Embedded Finance
+# Example Stripe Issuing and Treasury integration demonstrating Embedded Finance
 
 This demo is an application that allows you to quickly experiment with an Embedded Finance experience using Stripe Issuing & Treasury APIs.
 
@@ -23,25 +22,43 @@ In addition to these functions, there is also a *Test Data* section that will he
 
 ## Requirements
 
-* **A Stripe account**: You can sign up for a Stripe account here: https://dashboard.stripe.com/register
-* **Onboard onto Issuing and Treasury**:
-  * Issuing: [Instant Testmode](https://dashboard.stripe.com/setup/issuing/activate)
-  * Treasury: [Please contact sales](https://go.stripe.global/treasury-inquiry)
-* **Stripe API keys**: Available in your Stripe dashboard here: https://dashboard.stripe.com/test/apikeys
+- **A Stripe account**: You can sign up for a Stripe account here: <https://dashboard.stripe.com/register>
+- **Onboard onto Issuing and Treasury**:
+  - Issuing: [Instant Testmode](https://dashboard.stripe.com/setup/issuing/activate)
+  - Treasury: [Please contact sales](https://go.stripe.global/treasury-inquiry)
+- **Stripe API keys**: Available in your Stripe dashboard here: <https://dashboard.stripe.com/test/apikeys>
 
-## Installation instructions
+## No-code deploy demo to Render.com
+
+You can deploy this sample app directly to Render.com using the button below. This way you can try it out for yourself 
+quickly and without any coding. The button below will create a free database and web service instance.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/stripe-samples/issuing-treasury)
+
+When prompted, enter:
+
+* **Blueprint Name**: This can be anything (e.g. "Demo")
+* **Under Key / Value**:
+  * **STRIPE_SECRET_KEY**: Your Stripe account's testmode API key
+  * **NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY**: Your Stripe account's testmode publishable key
+
+Once you click "Apply", the infrastructure will begin spinning up. After approximately 5 minutes, click on the link to
+"issuing-treasury" on the page to go to the web service. There, you'll see a link at the top to the URL. It'll look
+something like "https://issuing-treasury-12gj.onrender.com".
+
+## Local installation instructions
 
 ### Installing the dependencies
 
 After cloning this repo, install the dependencies.
 
-    $ npm install
+    npm install
 
 ### Populating your .env file
 
 Copy the `.env.example` file on the root of your project to `.env`:
 
-    $ cp .env.example .env
+    cp .env.example .env
 
 Edit your new `.env` file and update the required information:
 
@@ -54,18 +71,18 @@ Edit your new `.env` file and update the required information:
 
 On a Mac, follow these instructions to install Postgres:
 
-    $ brew install postgresql@14
-    $ createuser -s postgres
+    brew install postgresql@14
+    createuser -s postgres
 
 You can learn more about the `createuser` step [here](https://stackoverflow.com/a/15309551).
 
 Now you need to create the database:
 
-    $ npx prisma db push
+    npx prisma db push
 
 If this fails for any reasons such as permissions being denied, there's an included idempotent script you can run:
 
-    $ ./db/setup-database.postgres.sh
+    ./db/setup-database.postgres.sh
 
 This will create a `issuing_treasury` database in your local Postgres instance.
 
@@ -73,8 +90,6 @@ This will create a `issuing_treasury` database in your local Postgres instance.
 
 In order to run the application, after you installed the dependencies and created the `.env` file run the following command:
 
-```bash
-npm run dev
-```
+    npm run dev
 
 *Notice: This application is intended to be an example, and it should not be run in production as is.*

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Edit your new `.env` file and update the required information:
 - **STRIPE_SECRET_KEY**: Your Stripe private key.
 - **NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY**: Your Stripe publishable key.
 - **NEXTAUTH_SECRET**: Used to encrypt the NextAuth.js JWT ([learn more](https://next-auth.js.org/configuration/options#nextauth_secret)). You can use `openssl rand -base64 32` to generate a new one.
-- **DEMO_HOST**: The host where your application will run (if local you can use `"http://localhost:3000"`)
+- **CONNECT_ONBOARDING_REDIRECT_URL**: The host where your application will run (if local you can use `"http://localhost:3000"`)
 
 ### Setting up the database
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "homemade-ham",
-  "version": "0.3.0",
+  "name": "issuing-treasury",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "homemade-ham",
-      "version": "0.3.0",
+      "name": "issuing-treasury",
+      "version": "0.0.0",
       "dependencies": {
         "@emotion/cache": "11.10.5",
         "@emotion/react": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "homemade-ham",
-  "version": "0.3.0",
+  "name": "issuing-treasury",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,28 @@
+services:
+- type: web
+  name: issuing-treasury
+  env: node
+  plan: free
+  buildCommand: npm install; npx prisma db push; npm run build;
+  startCommand: NEXTAUTH_URL=$RENDER_EXTERNAL_URL CONNECT_ONBOARDING_REDIRECT_URL=$RENDER_EXTERNAL_URL npm run start
+  autoDeploy: false
+  envVars:
+    - key: PORT
+      value: 10000
+    - key: DATABASE_URL
+      fromDatabase:
+        name: issuing-treasury-db
+        property: connectionString
+    - key: STRIPE_SECRET_KEY
+      sync: false
+    - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+      sync: false
+    - key: NEXTAUTH_SECRET
+      generateValue: true
+
+databases:
+- name: issuing-treasury-db
+  plan: free
+  databaseName: issuing_treasury
+  user: issuing_treasury
+  ipAllowList: [] # only allow internal connections

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -59,10 +59,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     company: {
       name: businessName,
     },
+    // FOR-DEMO-ONLY: We're hardcoding the business type to individual. You should either remove this line or modify it
+    // to collect the real business type from the user.
+    business_type: "individual",
     ...(isDemoMode() && {
-      // FOR-DEMO-ONLY: We're hardcoding the business type to individual. You should either remove this line or modify it
-      // to collect the real business type from the user.
-      business_type: "individual",
       // FOR-DEMO-ONLY: We're hardcoding the SSN to 000-00-0000 (Test SSN docs: https://stripe.com/docs/connect/testing#test-personal-id-numbers).
       // You should either remove this line or modify it to collect the actual SSN from the user in a real application.
       individual: {

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -89,7 +89,7 @@ const Page = () => {
                         Test Email:{" "}
                         <Chip
                           variant="outlined"
-                          label="enter any fake email"
+                          label="Enter any fake email"
                           size="small"
                         />
                       </li>

--- a/src/sections/test-data/test-data-create-received-credit.tsx
+++ b/src/sections/test-data/test-data-create-received-credit.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   Card,
   CardActions,
@@ -54,11 +55,7 @@ const TestDataCreateReceivedCredit = () => {
           Your Financial Account will receive $ 500.00 each time you press the
           button.
         </Typography>
-        {error && (
-          <Typography variant="body2" color="error" align="center">
-            {errorText}
-          </Typography>
-        )}
+        {error && <Alert severity="error">{errorText}</Alert>}
       </CardContent>
       <Divider />
       <CardActions sx={{ justifyContent: "center" }}>

--- a/src/utils/onboarding-helpers.ts
+++ b/src/utils/onboarding-helpers.ts
@@ -14,17 +14,18 @@ export const hasOutstandingRequirements = async (accountId: string) => {
 };
 
 export async function createAccountOnboardingUrl(accountId: string) {
-  if (process.env.DEMO_HOST == undefined) {
-    throw new Error("DEMO_HOST is not set");
+  if (process.env.CONNECT_ONBOARDING_REDIRECT_URL == undefined) {
+    throw new Error("CONNECT_ONBOARDING_REDIRECT_URL is not set");
   }
 
-  const host = process.env.DEMO_HOST;
+  const connectOnboardingRedirectUrl =
+    process.env.CONNECT_ONBOARDING_REDIRECT_URL;
 
   const { url } = await stripe.accountLinks.create({
     type: "account_onboarding",
     account: accountId,
-    refresh_url: host + "/onboard",
-    return_url: host + "/",
+    refresh_url: connectOnboardingRedirectUrl + "/onboard",
+    return_url: connectOnboardingRedirectUrl + "/",
   });
   return url;
 }


### PR DESCRIPTION
* Adds a button to the README file to deploy to Render.com
* Adds a `render.yaml` file to configure the infrastructure to quickly deploy a publicly accessible free demo