### PR TITLE
Tweak redirect when skipping onboarding (Part 2)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
       "alphabetize": {
         "order": "asc"
       }
-    }]
+    }],
+    "no-console": "warn"
   }
 }

--- a/src/pages/api/onboard.ts
+++ b/src/pages/api/onboard.ts
@@ -48,6 +48,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         // Fake phone number: https://stripe.com/docs/connect/testing
         phone: "0000000000",
       },
+      ...(skipOnboarding && { tos_acceptance: tosAcceptance }),
       // Faking Terms of Service acceptances
       settings: {
         card_issuing: {
@@ -57,7 +58,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
           tos_acceptance: tosAcceptance,
         },
       },
-      ...(skipOnboarding && { tos_acceptance: tosAcceptance }),
     };
 
     // FOR-DEMO-ONLY: We're using fake data for illustrative purposes in this demo. The fake data will be used to bypass

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -29,8 +29,9 @@ const Page = () => {
     e.preventDefault();
     setIsSkippingOnboarding(true);
     const response = await fetchApi("/api/onboard", { skipOnboarding: true });
+
     if (response.ok) {
-      router.push("/");
+      window.location.replace("/");
     } else {
       setIsSkippingOnboarding(false);
       throw new Error("Something went wrong");


### PR DESCRIPTION
* Does a full reload after skipping onboarding by using `window.location.replace`