### PR TITLE
Add authorization pages and test data generation UI

### DIFF
--- a/src/components/authorizations-table.tsx
+++ b/src/components/authorizations-table.tsx
@@ -1,0 +1,189 @@
+import { ArrowRightIcon } from "@heroicons/react/20/solid";
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  SvgIcon,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import React, { ChangeEvent } from "react";
+import Stripe from "stripe";
+
+import { SeverityPill } from "./severity-pill";
+
+import { Scrollbar } from "src/components/scrollbar";
+import { SeverityColor } from "src/types/severity-color";
+import { capitalize, formatDateTime, formatUSD } from "src/utils/format";
+
+const statusMap: Record<Stripe.Issuing.Authorization.Status, SeverityColor> = {
+  closed: "primary",
+  pending: "warning",
+  reversed: "error",
+};
+
+const AuthorizationsTable = ({
+  count = 0,
+  items = [],
+  onDeselectAll,
+  onDeselectOne,
+  onPageChange = () => ({}),
+  onRowsPerPageChange,
+  onSelectAll,
+  onSelectOne,
+  page = 0,
+  rowsPerPage = 0,
+  selected = [],
+}: {
+  count?: number;
+  items: Stripe.Issuing.Authorization[];
+  onDeselectAll: () => void;
+  onDeselectOne: (item: string) => void;
+  onPageChange: (
+    e: React.MouseEvent<HTMLButtonElement> | null,
+    page: number,
+  ) => void;
+  onRowsPerPageChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSelectAll: () => void;
+  onSelectOne: (item: string) => void;
+  page?: number;
+  rowsPerPage?: number;
+  selected?: string[];
+}) => {
+  const selectedSome = selected.length > 0 && selected.length < items.length;
+  const selectedAll = items.length > 0 && selected.length === items.length;
+
+  return (
+    <Card>
+      <Scrollbar sx={{ flexGrow: 1 }}>
+        <Box sx={{ minWidth: 800 }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    checked={selectedAll}
+                    indeterminate={selectedSome}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        onSelectAll?.();
+                      } else {
+                        onDeselectAll?.();
+                      }
+                    }}
+                  />
+                </TableCell>
+                <TableCell sortDirection="desc">Date</TableCell>
+                <TableCell>Amount</TableCell>
+                <TableCell>Name On Card</TableCell>
+                <TableCell>Card Last 4</TableCell>
+                <TableCell>{/* Approved? */}</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Merchant</TableCell>
+                <TableCell>Merchant Category</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {items.map((authorization) => {
+                const isSelected = selected.includes(authorization.id);
+                const category = authorization.merchant_data.category.replace(
+                  /_/g,
+                  " ",
+                );
+                return (
+                  <TableRow hover key={authorization.id}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={isSelected}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            onSelectOne?.(authorization.id);
+                          } else {
+                            onDeselectOne?.(authorization.id);
+                          }
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {formatDateTime(authorization.created)}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ textTransform: "uppercase" }}
+                    >
+                      <Typography noWrap>{`${formatUSD(
+                        authorization.amount / 100,
+                      )} USD`}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography noWrap>
+                        {authorization.card.cardholder.name}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>•••• {authorization.card.last4}</TableCell>
+                    <TableCell>
+                      <SeverityPill
+                        color={authorization.approved ? "success" : "error"}
+                      >
+                        {authorization.approved ? "Approved" : "Declined"}
+                      </SeverityPill>
+                    </TableCell>
+                    <TableCell>
+                      <SeverityPill color={statusMap[authorization.status]}>
+                        {capitalize(authorization.status)}
+                      </SeverityPill>
+                    </TableCell>
+                    <TableCell>
+                      <Typography noWrap>
+                        {authorization.merchant_data.name}
+                      </Typography>
+                    </TableCell>
+                    <TableCell sx={{ textTransform: "uppercase" }}>
+                      <Typography noWrap>{category}</Typography>
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        width: "1px",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      <Button
+                        color="inherit"
+                        endIcon={
+                          <SvgIcon fontSize="small">
+                            <ArrowRightIcon />
+                          </SvgIcon>
+                        }
+                        href={`/authorizations/${authorization.id}`}
+                      >
+                        Details
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </Box>
+      </Scrollbar>
+      <TablePagination
+        component="div"
+        count={count}
+        page={page}
+        onPageChange={onPageChange}
+        onRowsPerPageChange={onRowsPerPageChange}
+        rowsPerPage={rowsPerPage}
+        rowsPerPageOptions={[5, 10, 25]}
+      />
+    </Card>
+  );
+};
+
+export default AuthorizationsTable;

--- a/src/components/floating-test-panel.tsx
+++ b/src/components/floating-test-panel.tsx
@@ -1,0 +1,55 @@
+import { PlusCircleIcon } from "@heroicons/react/20/solid";
+import { Button, Drawer, Stack, SvgIcon } from "@mui/material";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/system/useTheme";
+import React, { ReactNode } from "react";
+
+const FloatingTestPanel = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => {
+  const theme = useTheme();
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        bottom: {
+          xs: theme.spacing(2),
+          sm: theme.spacing(6),
+        },
+        right: {
+          xs: theme.spacing(2),
+          sm: theme.spacing(6),
+        },
+      }}
+    >
+      <Button
+        variant="contained"
+        startIcon={
+          <SvgIcon fontSize="small">
+            <PlusCircleIcon />
+          </SvgIcon>
+        }
+        onClick={() => setOpen(true)}
+      >
+        Generate Test Data
+      </Button>
+      <Drawer anchor="right" open={open} onClose={() => setOpen(false)}>
+        <Stack spacing={3} maxWidth={400} p={3}>
+          <Typography variant="h6" fontWeight={600}>
+            {title}
+          </Typography>
+          {children}
+        </Stack>
+      </Drawer>
+    </Box>
+  );
+};
+
+export default FloatingTestPanel;

--- a/src/components/issuing/authorizations-table.tsx
+++ b/src/components/issuing/authorizations-table.tsx
@@ -16,7 +16,7 @@ import {
 import React, { ChangeEvent } from "react";
 import Stripe from "stripe";
 
-import { SeverityPill } from "./severity-pill";
+import { SeverityPill } from "../severity-pill";
 
 import { Scrollbar } from "src/components/scrollbar";
 import { SeverityColor } from "src/types/severity-color";

--- a/src/components/issuing/authorizations-table.tsx
+++ b/src/components/issuing/authorizations-table.tsx
@@ -80,9 +80,9 @@ const AuthorizationsTable = ({
                   />
                 </TableCell>
                 <TableCell sortDirection="desc">Date</TableCell>
-                <TableCell>Amount</TableCell>
+                <TableCell align="right">Amount</TableCell>
                 <TableCell>Name On Card</TableCell>
-                <TableCell>Card Last 4</TableCell>
+                <TableCell sx={{ whiteSpace: "nowrap" }}>Card Last 4</TableCell>
                 <TableCell>{/* Approved? */}</TableCell>
                 <TableCell>Status</TableCell>
                 <TableCell>Merchant</TableCell>
@@ -111,21 +111,17 @@ const AuthorizationsTable = ({
                         }}
                       />
                     </TableCell>
-                    <TableCell>
+                    <TableCell sx={{ whiteSpace: "nowrap" }}>
                       {formatDateTime(authorization.created)}
                     </TableCell>
                     <TableCell
                       align="right"
-                      sx={{ textTransform: "uppercase" }}
+                      sx={{ textTransform: "uppercase", whiteSpace: "nowrap" }}
                     >
-                      <Typography noWrap>{`${formatUSD(
-                        authorization.amount / 100,
-                      )} USD`}</Typography>
+                      {`${formatUSD(authorization.amount / 100)} USD`}
                     </TableCell>
-                    <TableCell>
-                      <Typography noWrap>
-                        {authorization.card.cardholder.name}
-                      </Typography>
+                    <TableCell sx={{ whiteSpace: "nowrap" }}>
+                      {authorization.card.cardholder.name}
                     </TableCell>
                     <TableCell>•••• {authorization.card.last4}</TableCell>
                     <TableCell>
@@ -140,13 +136,15 @@ const AuthorizationsTable = ({
                         {capitalize(authorization.status)}
                       </SeverityPill>
                     </TableCell>
-                    <TableCell>
+                    <TableCell sx={{ whiteSpace: "nowrap" }}>
                       <Typography noWrap>
                         {authorization.merchant_data.name}
                       </Typography>
                     </TableCell>
-                    <TableCell sx={{ textTransform: "uppercase" }}>
-                      <Typography noWrap>{category}</Typography>
+                    <TableCell
+                      sx={{ textTransform: "uppercase", whiteSpace: "nowrap" }}
+                    >
+                      {category}
                     </TableCell>
                     <TableCell
                       sx={{

--- a/src/layouts/dashboard/account-popover.tsx
+++ b/src/layouts/dashboard/account-popover.tsx
@@ -1,4 +1,7 @@
-import { ClipboardIcon } from "@heroicons/react/20/solid";
+import {
+  ArrowTopRightOnSquareIcon,
+  ClipboardIcon,
+} from "@heroicons/react/20/solid";
 import {
   Box,
   Divider,
@@ -9,6 +12,7 @@ import {
   SvgIcon,
   Typography,
 } from "@mui/material";
+import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
 
 export const AccountPopover = ({
@@ -67,6 +71,17 @@ export const AccountPopover = ({
               <ClipboardIcon />
             </SvgIcon>
           </IconButton>
+        </Typography>
+        <Typography color="text.secondary" variant="body2" mt={1}>
+          <Link
+            href={`https://dashboard.stripe.com/${session?.accountId}/test/issuing/overview`}
+            target="_blank"
+          >
+            {session?.accountId}
+            <SvgIcon sx={{ ml: 1, width: "20px", height: "20px" }}>
+              <ArrowTopRightOnSquareIcon />
+            </SvgIcon>
+          </Link>
         </Typography>
       </Box>
       <Divider />

--- a/src/layouts/dashboard/config.tsx
+++ b/src/layouts/dashboard/config.tsx
@@ -5,6 +5,7 @@ import {
   ChartBarIcon,
   UsersIcon,
   WrenchScrewdriverIcon,
+  ShoppingBagIcon,
 } from "@heroicons/react/24/solid";
 import { SvgIcon } from "@mui/material";
 
@@ -33,6 +34,15 @@ export const items = [
     icon: (
       <SvgIcon fontSize="small">
         <CreditCardIcon />
+      </SvgIcon>
+    ),
+  },
+  {
+    title: "Authorizations",
+    path: "/authorizations",
+    icon: (
+      <SvgIcon fontSize="small">
+        <ShoppingBagIcon />
       </SvgIcon>
     ),
   },

--- a/src/pages/authorizations.tsx
+++ b/src/pages/authorizations.tsx
@@ -1,0 +1,171 @@
+import {
+  ArrowUpOnSquareIcon,
+  ArrowDownOnSquareIcon,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/solid";
+import {
+  Box,
+  Container,
+  Stack,
+  Typography,
+  Button,
+  SvgIcon,
+  Card,
+  InputAdornment,
+  OutlinedInput,
+} from "@mui/material";
+import { GetServerSidePropsContext } from "next";
+import React, {
+  ChangeEvent,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import Stripe from "stripe";
+
+import AuthorizationsTable from "src/components/authorizations-table";
+import { useSelection } from "src/hooks/use-selection";
+import DashboardLayout from "src/layouts/dashboard/layout";
+import { applyPagination } from "src/utils/apply-pagination";
+import { getSessionForServerSideProps } from "src/utils/session-helpers";
+import { getAuthorizations } from "src/utils/stripe_helpers";
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  const session = await getSessionForServerSideProps(context);
+  const StripeAccountID = session.accountId;
+  const responseAuthorizations = await getAuthorizations(StripeAccountID);
+
+  return {
+    props: {
+      authorizations: responseAuthorizations.authorizations.data,
+    },
+  };
+};
+
+function useAuthorizations(
+  authorizations: Stripe.Issuing.Authorization[],
+  page: number,
+  rowsPerPage: number,
+): Stripe.Issuing.Authorization[] {
+  return useMemo(() => {
+    return applyPagination(authorizations, page, rowsPerPage);
+  }, [authorizations, page, rowsPerPage]);
+}
+
+function useAuthorizationIds(
+  authorizations: Stripe.Issuing.Authorization[],
+): string[] {
+  return useMemo(() => {
+    return authorizations.map((authorization) => authorization.id);
+  }, [authorizations]);
+}
+
+const Page = ({
+  authorizations: allAuthorizations,
+}: {
+  authorizations: Stripe.Issuing.Authorization[];
+}) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const authorizations = useAuthorizations(
+    allAuthorizations,
+    page,
+    rowsPerPage,
+  );
+  const authorizationsIds = useAuthorizationIds(authorizations);
+  const authorizationsSelection = useSelection<string>(authorizationsIds);
+
+  const handlePageChange = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement> | null, page: number) => {
+      setPage(page);
+    },
+    [],
+  );
+
+  const handleRowsPerPageChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const rows = parseInt(e.target.value);
+      setRowsPerPage(rows);
+    },
+    [],
+  );
+
+  return (
+    <>
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          py: 8,
+        }}
+      >
+        <Container maxWidth="xl">
+          <Stack spacing={3}>
+            <Stack direction="row" justifyContent="space-between" spacing={4}>
+              <Stack spacing={1}>
+                <Typography variant="h4">Authorizations</Typography>
+                <Stack alignItems="center" direction="row" spacing={1}>
+                  <Button
+                    color="inherit"
+                    startIcon={
+                      <SvgIcon fontSize="small">
+                        <ArrowUpOnSquareIcon />
+                      </SvgIcon>
+                    }
+                  >
+                    Import
+                  </Button>
+                  <Button
+                    color="inherit"
+                    startIcon={
+                      <SvgIcon fontSize="small">
+                        <ArrowDownOnSquareIcon />
+                      </SvgIcon>
+                    }
+                  >
+                    Export
+                  </Button>
+                </Stack>
+              </Stack>
+            </Stack>
+            <Card sx={{ p: 2 }}>
+              <OutlinedInput
+                defaultValue=""
+                fullWidth
+                placeholder="Search authorizations"
+                startAdornment={
+                  <InputAdornment position="start">
+                    <SvgIcon color="action" fontSize="small">
+                      <MagnifyingGlassIcon />
+                    </SvgIcon>
+                  </InputAdornment>
+                }
+                sx={{ maxWidth: 500 }}
+              />
+            </Card>
+            <AuthorizationsTable
+              count={allAuthorizations.length}
+              items={authorizations}
+              onDeselectAll={authorizationsSelection.handleDeselectAll}
+              onDeselectOne={authorizationsSelection.handleDeselectOne}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowsPerPageChange}
+              onSelectAll={authorizationsSelection.handleSelectAll}
+              onSelectOne={authorizationsSelection.handleSelectOne}
+              page={page}
+              rowsPerPage={rowsPerPage}
+              selected={authorizationsSelection.selected}
+            />
+          </Stack>
+        </Container>
+      </Box>
+    </>
+  );
+};
+
+Page.getLayout = (page: ReactNode) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/authorizations.tsx
+++ b/src/pages/authorizations.tsx
@@ -24,7 +24,7 @@ import React, {
 } from "react";
 import Stripe from "stripe";
 
-import AuthorizationsTable from "src/components/authorizations-table";
+import AuthorizationsTable from "src/components/issuing/authorizations-table";
 import { useSelection } from "src/hooks/use-selection";
 import DashboardLayout from "src/layouts/dashboard/layout";
 import { applyPagination } from "src/utils/apply-pagination";

--- a/src/pages/authorizations/[authorizationId].tsx
+++ b/src/pages/authorizations/[authorizationId].tsx
@@ -1,0 +1,160 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  Container,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { GetServerSidePropsContext } from "next";
+import React, { ReactNode } from "react";
+import Stripe from "stripe";
+
+import { SeverityPill } from "src/components/severity-pill";
+import DashboardLayout from "src/layouts/dashboard/layout";
+import { SeverityColor } from "src/types/severity-color";
+import {
+  capitalize,
+  formatDateAndTime,
+  formatUSD,
+  titleize,
+} from "src/utils/format";
+import { getSessionForServerSideProps } from "src/utils/session-helpers";
+import { getAuthorizationDetails } from "src/utils/stripe_helpers";
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  const session = await getSessionForServerSideProps(context);
+  const authorizationId = context?.params?.authorizationId?.toString();
+  if (authorizationId === undefined) {
+    throw new Error("authorizationId must be provided");
+  }
+  const StripeAccountID = session.accountId;
+  const result = await getAuthorizationDetails(
+    StripeAccountID,
+    authorizationId,
+  );
+
+  return {
+    props: {
+      authorization: result.authorization,
+    },
+  };
+};
+
+const statusMap: Record<Stripe.Issuing.Authorization.Status, SeverityColor> = {
+  closed: "primary",
+  pending: "warning",
+  reversed: "error",
+};
+
+const Page = ({
+  authorization,
+}: {
+  authorization: Stripe.Issuing.Authorization;
+}) => {
+  return (
+    <Box
+      component="main"
+      sx={{
+        flexGrow: 1,
+        py: 8,
+      }}
+    >
+      <Container maxWidth="xl">
+        <Typography variant="h4">Authorization Details</Typography>
+        <Card sx={{ mt: 4 }}>
+          <CardContent>
+            <Grid container rowSpacing={3}>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">ID</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {authorization.id}
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Card</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    •••• {authorization.card.last4}
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Location</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {authorization.merchant_data.city +
+                      ", " +
+                      authorization.merchant_data.state +
+                      ", " +
+                      authorization.merchant_data.postal_code +
+                      ", " +
+                      authorization.merchant_data.country}
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Date / Time</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {formatDateAndTime(authorization.created)}
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Amount</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {`${formatUSD(authorization.amount / 100)} USD`}
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Status</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Stack direction="row" spacing={1}>
+                    <SeverityPill
+                      color={authorization.approved ? "success" : "error"}
+                    >
+                      {authorization.approved ? "Approved" : "Declined"}
+                    </SeverityPill>
+                    <SeverityPill color={statusMap[authorization.status]}>
+                      {capitalize(authorization.status)}
+                    </SeverityPill>
+                  </Stack>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Merchant</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {authorization.merchant_data.name}
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <Typography variant="subtitle2">Merchant Category</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {titleize(
+                      authorization.merchant_data.category.replace(/_/g, " "),
+                    )}
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+      </Container>
+    </Box>
+  );
+};
+
+Page.getLayout = (page: ReactNode) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/cards/[cardId].tsx
+++ b/src/pages/cards/[cardId].tsx
@@ -1,3 +1,4 @@
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 import { CurrencyDollarIcon } from "@heroicons/react/24/solid";
 import {
   Avatar,
@@ -13,9 +14,12 @@ import {
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { GetServerSidePropsContext } from "next";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
 import React, { ReactNode } from "react";
 import Stripe from "stripe";
 
+import FloatingTestPanel from "src/components/floating-test-panel";
 import DashboardLayout from "src/layouts/dashboard/layout";
 import CardDetails from "src/sections/[cardId]/card-details";
 import CardIllustration from "src/sections/[cardId]/card-illustration";
@@ -143,7 +147,39 @@ const Page = ({
           </Grid>
         </Container>
       </Box>
+      <GenerateTestDataDrawer cardId={cardId} />
     </>
+  );
+};
+
+// FOR-DEMO-ONLY: This component is only useful for generating test data for demonstration purposes and can be removed
+// for a real application.
+const GenerateTestDataDrawer = ({ cardId }: { cardId: string }) => {
+  const { data: session } = useSession();
+
+  return (
+    <FloatingTestPanel title="Create a test authorization">
+      <Typography variant="body2">
+        You can create a test authorization by{" "}
+        <Link
+          href={`https://dashboard.stripe.com/${session?.accountId}/test/issuing/cards/${cardId}`}
+          target="_blank"
+        >
+          going to this card&apos;s overview in the Stripe dashboard
+          <SvgIcon
+            sx={{
+              ml: 0.5,
+              width: "20px",
+              height: "20px",
+              verticalAlign: "middle",
+            }}
+          >
+            <ArrowTopRightOnSquareIcon />
+          </SvgIcon>
+        </Link>{" "}
+        and clicking on the &quot;Create test authorization&quot; button.
+      </Typography>
+    </FloatingTestPanel>
   );
 };
 

--- a/src/sections/[cardId]/latest-card-authorizations.tsx
+++ b/src/sections/[cardId]/latest-card-authorizations.tsx
@@ -1,3 +1,4 @@
+import { ArrowRightIcon } from "@heroicons/react/20/solid";
 import {
   Card,
   CardHeader,
@@ -9,21 +10,30 @@ import {
   TableBody,
   Typography,
   Divider,
+  Button,
+  SvgIcon,
 } from "@mui/material";
 import React from "react";
 import Stripe from "stripe";
 
 import { Scrollbar } from "src/components/scrollbar";
 import { SeverityPill } from "src/components/severity-pill";
-import { formatDateTime, formatUSD } from "src/utils/format";
+import { SeverityColor } from "src/types/severity-color";
+import { capitalize, formatDateTime, formatUSD } from "src/utils/format";
 
-function LatestCardAuthorizations({
+const statusMap: Record<Stripe.Issuing.Authorization.Status, SeverityColor> = {
+  closed: "primary",
+  pending: "warning",
+  reversed: "error",
+};
+
+const LatestCardAuthorizations = ({
   authorizations,
   sx,
 }: {
   authorizations: Stripe.Issuing.Authorization[];
   sx?: object;
-}) {
+}) => {
   return (
     <>
       <Card sx={sx}>
@@ -35,11 +45,12 @@ function LatestCardAuthorizations({
                 <TableHead>
                   <TableRow>
                     <TableCell sortDirection="desc">Date</TableCell>
-                    <TableCell>Merchant</TableCell>
-                    <TableCell>Amount</TableCell>
+                    <TableCell align="right">Amount</TableCell>
+                    <TableCell>{/* Approved? */}</TableCell>
                     <TableCell>Status</TableCell>
+                    <TableCell>Merchant</TableCell>
                     <TableCell>Merchant Category</TableCell>
-                    <TableCell>ID</TableCell>
+                    <TableCell></TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -48,21 +59,17 @@ function LatestCardAuthorizations({
                       authorization.merchant_data.category.replace(/_/g, " ");
                     return (
                       <TableRow hover key={authorization.id}>
-                        <TableCell>
-                          <Typography noWrap>
-                            {formatDateTime(authorization.created)}
-                          </Typography>
+                        <TableCell sx={{ whiteSpace: "nowrap" }}>
+                          {formatDateTime(authorization.created)}
                         </TableCell>
-                        <TableCell>
-                          <Typography noWrap>
-                            {authorization.merchant_data.name}{" "}
-                          </Typography>
-                        </TableCell>
-                        <TableCell sx={{ textTransform: "uppercase" }}>
-                          <Typography noWrap>
-                            {formatUSD(authorization.amount / 100)}{" "}
-                            {authorization.currency}
-                          </Typography>
+                        <TableCell
+                          align="right"
+                          sx={{
+                            textTransform: "uppercase",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {`${formatUSD(authorization.amount / 100)} USD`}
                         </TableCell>
                         <TableCell>
                           <SeverityPill
@@ -71,10 +78,42 @@ function LatestCardAuthorizations({
                             {authorization.approved ? "Approved" : "Declined"}
                           </SeverityPill>
                         </TableCell>
-                        <TableCell sx={{ textTransform: "uppercase" }}>
-                          <Typography noWrap>{category}</Typography>
+                        <TableCell>
+                          <SeverityPill color={statusMap[authorization.status]}>
+                            {capitalize(authorization.status)}
+                          </SeverityPill>
                         </TableCell>
-                        <TableCell>{authorization.id}</TableCell>
+                        <TableCell sx={{ whiteSpace: "nowrap" }}>
+                          <Typography noWrap>
+                            {authorization.merchant_data.name}
+                          </Typography>
+                        </TableCell>
+                        <TableCell
+                          sx={{
+                            textTransform: "uppercase",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {category}
+                        </TableCell>
+                        <TableCell
+                          sx={{
+                            width: "1px",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          <Button
+                            color="inherit"
+                            endIcon={
+                              <SvgIcon fontSize="small">
+                                <ArrowRightIcon />
+                              </SvgIcon>
+                            }
+                            href={`/authorizations/${authorization.id}`}
+                          >
+                            Details
+                          </Button>
+                        </TableCell>
                       </TableRow>
                     );
                   })}
@@ -95,6 +134,6 @@ function LatestCardAuthorizations({
       </Card>
     </>
   );
-}
+};
 
 export default LatestCardAuthorizations;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -14,6 +14,16 @@ export function formatDateTime(secondsSinceEpoch: number) {
   return format(fromUnixTime(secondsSinceEpoch), "MMM dd, yyyy");
 }
 
+export function formatDateAndTime(secondsSinceEpoch: number) {
+  return format(fromUnixTime(secondsSinceEpoch), "MMM dd, yyyy 'at' h:mm a");
+}
+
 export function capitalize(value: string) {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function titleize(str: string) {
+  return str
+    .toLowerCase()
+    .replace(/(?:^|\s|-)\w/g, (match) => match.toUpperCase());
 }

--- a/src/utils/stripe_helpers.ts
+++ b/src/utils/stripe_helpers.ts
@@ -225,6 +225,20 @@ export async function getAuthorizations(StripeAccountID: string) {
   );
 
   return {
-    authorizations: authorizations,
+    authorizations,
+  };
+}
+
+export async function getAuthorizationDetails(
+  StripeAccountID: string,
+  authorizationId: string,
+) {
+  const authorization = await stripe.issuing.authorizations.retrieve(
+    authorizationId,
+    { stripeAccount: StripeAccountID },
+  );
+
+  return {
+    authorization,
   };
 }

--- a/src/utils/stripe_helpers.ts
+++ b/src/utils/stripe_helpers.ts
@@ -217,3 +217,14 @@ export async function getCardDetails(StripeAccountID: string, cardId: string) {
 
   return cardTransactions;
 }
+
+export async function getAuthorizations(StripeAccountID: string) {
+  const authorizations = await stripe.issuing.authorizations.list(
+    { limit: 10 },
+    { stripeAccount: StripeAccountID },
+  );
+
+  return {
+    authorizations: authorizations,
+  };
+}


### PR DESCRIPTION
* Adds an authorization page to show all authorizations
* Updates the authorization table on the card details page
* Links from both of the above to an authorization details page
* Card details page has a new "Generate Test Data" button that opens a MUI drawer to help with creating test authorizations