### PR TITLE
Hide debug UI behind a query parameter or if in demo mode

### DIFF
--- a/src/layouts/dashboard/account-popover.tsx
+++ b/src/layouts/dashboard/account-popover.tsx
@@ -13,7 +13,10 @@ import {
   Typography,
 } from "@mui/material";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { signOut, useSession } from "next-auth/react";
+
+import { isDemoMode } from "src/utils/demo-helpers";
 
 export const AccountPopover = ({
   anchorEl,
@@ -25,6 +28,7 @@ export const AccountPopover = ({
   open: boolean;
 }) => {
   const { data: session } = useSession();
+  const router = useRouter();
 
   const handleLogout = async () => {
     onClose?.();
@@ -72,17 +76,19 @@ export const AccountPopover = ({
             </SvgIcon>
           </IconButton>
         </Typography>
-        <Typography color="text.secondary" variant="body2" mt={1}>
-          <Link
-            href={`https://dashboard.stripe.com/${session?.accountId}/test/issuing/overview`}
-            target="_blank"
-          >
-            {session?.accountId}
-            <SvgIcon sx={{ ml: 1, width: "20px", height: "20px" }}>
-              <ArrowTopRightOnSquareIcon />
-            </SvgIcon>
-          </Link>
-        </Typography>
+        {(!isDemoMode() || router.query.debug) && (
+          <Typography color="text.secondary" variant="body2" mt={1}>
+            <Link
+              href={`https://dashboard.stripe.com/${session?.accountId}/test/issuing/overview`}
+              target="_blank"
+            >
+              {session?.accountId}
+              <SvgIcon sx={{ ml: 1, width: "20px", height: "20px" }}>
+                <ArrowTopRightOnSquareIcon />
+              </SvgIcon>
+            </Link>
+          </Typography>
+        )}
       </Box>
       <Divider />
       <MenuList

--- a/src/pages/cards/[cardId].tsx
+++ b/src/pages/cards/[cardId].tsx
@@ -15,6 +15,7 @@ import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { GetServerSidePropsContext } from "next";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import React, { ReactNode } from "react";
 import Stripe from "stripe";
@@ -24,6 +25,7 @@ import DashboardLayout from "src/layouts/dashboard/layout";
 import CardDetails from "src/sections/[cardId]/card-details";
 import CardIllustration from "src/sections/[cardId]/card-illustration";
 import LatestCardAuthorizations from "src/sections/[cardId]/latest-card-authorizations";
+import { isDemoMode } from "src/utils/demo-helpers";
 import { formatUSD } from "src/utils/format";
 import { getSessionForServerSideProps } from "src/utils/session-helpers";
 import { getCardDetails } from "src/utils/stripe_helpers";
@@ -63,6 +65,8 @@ const Page = ({
   cardId: string;
   card: Stripe.Issuing.Card;
 }) => {
+  const router = useRouter();
+
   const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
   if (stripePublishableKey === undefined) {
     throw new Error("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY must be defined");
@@ -147,7 +151,10 @@ const Page = ({
           </Grid>
         </Container>
       </Box>
-      <GenerateTestDataDrawer cardId={cardId} />
+      {/* The demo mode flag can be removed from here once the Issuing spend card test helpers are GA-ed */}
+      {(!isDemoMode() || router.query.debug) && (
+        <GenerateTestDataDrawer cardId={cardId} />
+      )}
     </>
   );
 };

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -21,7 +21,7 @@ const Page = () => {
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const router = useRouter();
 
-  const [skipOnboarding, setSkipOnboarding] = useState(false);
+  const [skipOnboarding, setSkipOnboarding] = useState(true);
 
   const handleSkipOnboarding = async (
     e: React.MouseEvent<HTMLButtonElement>,

--- a/src/sections/test-data/test-data-create-payment-link.tsx
+++ b/src/sections/test-data/test-data-create-payment-link.tsx
@@ -6,11 +6,19 @@ import {
   CardHeader,
   Divider,
   Link,
+  Stack,
   Typography,
 } from "@mui/material";
+import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
 import React, { useState } from "react";
 
+import { isDemoMode } from "src/utils/demo-helpers";
+
 function TestDataCreatePaymentLink() {
+  const { data: session } = useSession();
+  const router = useRouter();
+
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState(false);
   const [errorText, setErrorText] = useState("");
@@ -46,22 +54,42 @@ function TestDataCreatePaymentLink() {
     <Card>
       <CardHeader title="Create PaymentLink" />
       <CardContent sx={{ pt: 0 }}>
-        <Typography>
-          By pressing the Create PaymentLink button you will generate a{" "}
-          <Link
-            href="https://stripe.com/docs/payments/payment-links"
-            target="_blank"
-          >
-            PaymentLink
-          </Link>{" "}
-          that you can use to receive a payment into your Connected
-          Account&apos;s Stripe Balance.
-        </Typography>
-        {error && (
-          <Typography variant="body2" color="error" align="center">
-            {errorText}
+        <Stack spacing={1}>
+          <Typography>
+            By pressing the Create PaymentLink button you will generate a{" "}
+            <Link
+              href="https://stripe.com/docs/payments/payment-links"
+              target="_blank"
+            >
+              PaymentLink
+            </Link>{" "}
+            that you can use to receive a payment into your Connected
+            Account&apos;s Stripe Balance.
           </Typography>
-        )}
+          <Typography>
+            Use the test card number{" "}
+            <Typography variant="button">4000 0000 0000 0077</Typography> which
+            will cause the charge to succeed. Funds are added directly to your
+            available balance, bypassing your pending balance.
+          </Typography>
+          {(!isDemoMode() || router.query.debug) && (
+            <Typography>
+              You can view the payments{" "}
+              <Link
+                href={`https://dashboard.stripe.com/${session?.accountId}/test/payments`}
+                target="_blank"
+              >
+                here
+              </Link>{" "}
+              in the Stripe dashboard.
+            </Typography>
+          )}
+          {error && (
+            <Typography variant="body2" color="error" align="center">
+              {errorText}
+            </Typography>
+          )}
+        </Stack>
       </CardContent>
       <Divider />
       <CardActions sx={{ justifyContent: "center" }}>

--- a/src/sections/test-data/test-data-create-payout.tsx
+++ b/src/sections/test-data/test-data-create-payout.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   Divider,
   Link,
+  Stack,
   Typography,
 } from "@mui/material";
 import React, { useState } from "react";
@@ -81,42 +82,44 @@ function TestDataCreatePayout(props: {
     <Card>
       <CardHeader title="Create Payout" />
       <CardContent sx={{ pt: 0 }}>
-        <Typography>
-          In order to enable payouts, you need to set your Financial Account as
-          the external account for your Connected Account.
-        </Typography>
-        <Typography>
-          {`If you haven't done it yet, by pressing the "Add Financial
+        <Stack spacing={1}>
+          <Typography>
+            In order to enable payouts, you need to set your Financial Account
+            as the external account for your Connected Account.
+          </Typography>
+          <Typography>
+            {`If you haven't done it yet, by pressing the "Add Financial
           Account as External Account" button, the Financial Account will be set
           as an external account, and manual payouts will be enabled.`}
-        </Typography>
-        <Typography>
-          Platforms have the ability to set up automatic payouts with different
-          schedules. You can dive deep into this topic on{" "}
-          <Link
-            href="https://stripe.com/docs/treasury/moving-money/payouts"
-            target="_blank"
-          >
-            this page
-          </Link>
-          .
-        </Typography>
-        <Typography>
-          Currently, your connected account has an{" "}
-          <Link
-            href="https://stripe.com/docs/connect/account-balances"
-            target="_blank"
-          >
-            Available Balance
-          </Link>{" "}
-          of <strong>{formatter.format(availableBalance / 100)}</strong>.
-        </Typography>
-
-        {error && (
-          <Typography variant="body2" color="error" align="center">
-            {errorText}
           </Typography>
-        )}
+          <Typography>
+            Platforms have the ability to set up automatic payouts with
+            different schedules. You can dive deep into this topic on{" "}
+            <Link
+              href="https://stripe.com/docs/treasury/moving-money/payouts"
+              target="_blank"
+            >
+              this page
+            </Link>
+            .
+          </Typography>
+          <Typography>
+            Currently, your connected account has an{" "}
+            <Link
+              href="https://stripe.com/docs/connect/account-balances"
+              target="_blank"
+            >
+              Available Balance
+            </Link>{" "}
+            of <strong>{formatter.format(availableBalance / 100)}</strong>.
+          </Typography>
+
+          {error && (
+            <Typography variant="body2" color="error" align="center">
+              {errorText}
+            </Typography>
+          )}
+        </Stack>
       </CardContent>
       <Divider />
       <CardActions sx={{ justifyContent: "center" }}>

--- a/src/sections/test-data/test-data-create-received-credit.tsx
+++ b/src/sections/test-data/test-data-create-received-credit.tsx
@@ -6,6 +6,7 @@ import {
   CardContent,
   CardHeader,
   Divider,
+  Stack,
   Typography,
 } from "@mui/material";
 import React, { useState } from "react";
@@ -35,19 +36,21 @@ const TestDataCreateReceivedCredit = () => {
     <Card>
       <CardHeader title="Simulate Received Credit"></CardHeader>
       <CardContent sx={{ pt: 0 }}>
-        <Typography>
-          By pressing the Create Received Credit button, you will simulate
-          receiving a transfer into your Financial Account.
-        </Typography>
-        <Typography>
-          You can send funds directly to your Financial Account via ACH or Wire
-          Transfers by using its Account and Routing numbers.
-        </Typography>
-        <Typography>
-          Your Financial Account will receive $ 500.00 each time you press the
-          button.
-        </Typography>
-        {errorText !== "" && <Alert severity="error">{errorText}</Alert>}
+        <Stack spacing={1}>
+          <Typography>
+            By pressing the Create Received Credit button, you will simulate
+            receiving a transfer into your Financial Account.
+          </Typography>
+          <Typography>
+            You can send funds directly to your Financial Account via ACH or
+            Wire Transfers by using its Account and Routing numbers.
+          </Typography>
+          <Typography>
+            Your Financial Account will receive $ 500.00 each time you press the
+            button.
+          </Typography>
+          {errorText !== "" && <Alert severity="error">{errorText}</Alert>}
+        </Stack>
       </CardContent>
       <Divider />
       <CardActions sx={{ justifyContent: "center" }}>


### PR DESCRIPTION
* Hides debug related UIs behind a query parameter `?debug=true` or if the environment variable `NEXT_PUBLIC_DEMO_MODE` is set to true
* Changes the checkbox for skipping onboarding to be on by default