### PR TITLE
Move simulate received credit button

### DIFF
--- a/src/layouts/auth/layout.tsx
+++ b/src/layouts/auth/layout.tsx
@@ -158,8 +158,8 @@ const CookieBanner = () => {
             <Stack spacing={1} direction="row">
               <Box display="flex" alignItems="center" pl={1}>
                 <Typography color="neutral.500">
-                  This site uses cookies to enable the necessary functions and
-                  features such as login and account management services.
+                  This site uses necessary cookies to enable required functions
+                  and features, such as login and account management services.
                 </Typography>
               </Box>
               <IconButton onClick={handleAcknowledgingCookieNotice}>

--- a/src/layouts/dashboard/config.tsx
+++ b/src/layouts/dashboard/config.tsx
@@ -56,16 +56,6 @@ export const items = [
     ),
   },
   {
-    title: "Settings",
-    path: "/settings",
-    icon: (
-      <SvgIcon fontSize="small">
-        <CogIcon />
-      </SvgIcon>
-    ),
-  },
-
-  {
     title: "Test Data",
     path: "/test-data",
     icon: (

--- a/src/layouts/dashboard/side-nav.tsx
+++ b/src/layouts/dashboard/side-nav.tsx
@@ -100,29 +100,8 @@ export const SideNav = (props: { onClose: () => void; open: boolean }) => {
           textAlign="center"
         >
           <Typography color="neutral.100" variant="subtitle2">
-            This is an embedded finance demo
+            Stripe Issuing & Treasury Demo
           </Typography>
-          <Typography color="neutral.500" variant="body2">
-            Check out our docs to learn more
-          </Typography>
-          <Box
-            sx={{
-              display: "flex",
-              mt: 2,
-              mx: "auto",
-              width: "160px",
-              "& img": {
-                width: "100%",
-              },
-            }}
-          >
-            <Image
-              alt="Issuing Credit Cards"
-              src="/assets/issuing-credit-cards.png"
-              width="160"
-              height="134"
-            />
-          </Box>
           <Button
             component="a"
             endIcon={

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { CssBaseline } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 import { NextComponentType, NextPageContext } from "next";
 import { AppProps } from "next/app";
+import Head from "next/head";
 import { SessionProvider, useSession } from "next-auth/react";
 import React, { ReactElement } from "react";
 
@@ -36,6 +37,13 @@ export default function App({
 
   return (
     <CacheProvider value={emotionCache}>
+      <Head>
+        <title>Stripe Issuing & Treasury Demo</title>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1"
+        />
+      </Head>
       <SessionProvider session={session}>
         <ThemeProvider theme={theme}>
           <CssBaseline />

--- a/src/pages/api/create_receivedcredit.ts
+++ b/src/pages/api/create_receivedcredit.ts
@@ -1,38 +1,59 @@
 import { NextApiRequest, NextApiResponse } from "next";
 
+import { apiResponse } from "src/types/api-response";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripe from "src/utils/stripe-loader";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.method !== "POST") {
-    return res.status(400).json({ error: "Bad Request" });
-  }
-
   try {
-    const session = await getSessionForServerSide(req, res);
-    const StripeAccountId = session.accountId;
-
-    // Get financial accounts for the Connected Account
-    const financialAccounts = await stripe.treasury.financialAccounts.list(
-      { expand: ["data.financial_addresses.aba.account_number"] },
-      { stripeAccount: StripeAccountId },
-    );
-    const financialAccount = financialAccounts.data[0];
-
-    const receivedCredit =
-      await stripe.testHelpers.treasury.receivedCredits.create(
-        {
-          amount: 50000,
-          currency: "usd",
-          financial_account: financialAccount.id,
-          network: "ach",
+    switch (req.method) {
+      case "POST":
+        return await simulateReceivedCredit(req, res);
+      default:
+        return res
+          .status(400)
+          .json(
+            apiResponse({ success: false, error: { message: "Bad Request" } }),
+          );
+    }
+  } catch (error) {
+    return res.status(500).json(
+      apiResponse({
+        success: false,
+        error: {
+          message: (error as Error).message,
+          details: (error as Error).stack,
         },
-        { stripeAccount: StripeAccountId },
-      );
-    return res.json({ receivedCredit: receivedCredit.id });
-  } catch (err) {
-    return res.status(500).json({ error: (err as Error).message });
+      }),
+    );
   }
+};
+
+const simulateReceivedCredit = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => {
+  const session = await getSessionForServerSide(req, res);
+  const StripeAccountId = session.accountId;
+
+  // Get financial accounts for the Connected Account
+  const financialAccounts = await stripe.treasury.financialAccounts.list(
+    { expand: ["data.financial_addresses.aba.account_number"] },
+    { stripeAccount: StripeAccountId },
+  );
+  const financialAccount = financialAccounts.data[0];
+
+  await stripe.testHelpers.treasury.receivedCredits.create(
+    {
+      amount: 50000,
+      currency: "usd",
+      financial_account: financialAccount.id,
+      network: "ach",
+    },
+    { stripeAccount: StripeAccountId },
+  );
+
+  return res.json(apiResponse({ success: true }));
 };
 
 export default handler;

--- a/src/pages/financial_account.tsx
+++ b/src/pages/financial_account.tsx
@@ -16,11 +16,13 @@ import { GetServerSidePropsContext } from "next";
 import React, { ReactNode } from "react";
 import Stripe from "stripe";
 
+import FloatingTestPanel from "src/components/floating-test-panel";
 import DashboardLayout from "src/layouts/dashboard/layout";
 import SendMoneyWizardDialog from "src/sections/financial-account/send-money-wizard-dialog";
 import { OverviewFinancialAccountBalance } from "src/sections/overview/overview-fa-balance";
 import { OverviewFinancialAccountOutboundPending } from "src/sections/overview/overview-fa-outbound-pending";
 import { OverviewLatestTransactions } from "src/sections/overview/overview-latest-transactions";
+import TestDataCreateReceivedCredit from "src/sections/test-data/test-data-create-received-credit";
 import { getSessionForServerSideProps } from "src/utils/session-helpers";
 import {
   getFinancialAccountDetailsExp,
@@ -196,18 +198,22 @@ const Page = ({
                     <Typography color="text.secondary" variant="overline">
                       Supported Networks
                     </Typography>
-                    {financialAccount.financial_addresses[0].supported_networks?.map(
-                      (network, i) => (
-                        <Chip
-                          key={i}
-                          sx={{ ml: 1 }}
-                          label={network.toUpperCase().replace(/_/g, " ")}
-                          color="primary"
-                          variant="outlined"
-                        />
-                      ),
-                    )}
-                    <SendMoneyWizardDialog />
+                    <Box>
+                      {financialAccount.financial_addresses[0].supported_networks?.map(
+                        (network, i) => (
+                          <Chip
+                            key={i}
+                            sx={{ ml: 1 }}
+                            label={network.toUpperCase().replace(/_/g, " ")}
+                            color="primary"
+                            variant="outlined"
+                          />
+                        ),
+                      )}
+                    </Box>
+                    <Box pt={1}>
+                      <SendMoneyWizardDialog />
+                    </Box>
                   </Stack>
                 </CardContent>
               </Card>
@@ -218,6 +224,9 @@ const Page = ({
           </Grid>
         </Container>
       </Box>
+      <FloatingTestPanel title="Simulate a received credit">
+        <TestDataCreateReceivedCredit />
+      </FloatingTestPanel>
     </>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,6 +17,8 @@ import {
   getFinancialAccountTransactionDetails,
   getFinancialAccountTransactionsExpanded,
 } from "src/utils/stripe_helpers";
+import FloatingTestPanel from "src/components/floating-test-panel";
+import TestDataCreateReceivedCredit from "src/sections/test-data/test-data-create-received-credit";
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext,
@@ -84,6 +86,9 @@ const Page = ({
           </Grid>
         </Container>
       </Box>
+      <FloatingTestPanel title="Simulate a received credit">
+        <TestDataCreateReceivedCredit />
+      </FloatingTestPanel>
     </>
   );
 };

--- a/src/pages/test-data.tsx
+++ b/src/pages/test-data.tsx
@@ -53,9 +53,6 @@ const Page = ({
         <Container maxWidth="xl">
           <Grid container spacing={3} justifyContent="center">
             <Grid item xs={12} sm={10} md={8}>
-              <TestDataCreateReceivedCredit />
-            </Grid>
-            <Grid item xs={12} sm={10} md={8}>
               <TestDataCreatePaymentLink />
             </Grid>
             <Grid item xs={12} sm={10} md={8}>

--- a/src/sections/cardholders/cardholder-create-widget.tsx
+++ b/src/sections/cardholders/cardholder-create-widget.tsx
@@ -46,10 +46,12 @@ const CreateCardholderForm = ({
     state: Yup.string().required("State / Province is required"),
     postalCode: Yup.string().required("ZIP / Postal code is required"),
     country: Yup.string().required("Country is required"),
-    accept: Yup.boolean().oneOf(
-      [true],
-      "You must accept the terms and privacy policy",
-    ),
+    accept: Yup.boolean()
+      .required("The terms of service and privacy policy must be accepted.")
+      .oneOf(
+        [true],
+        "The terms of service and privacy policy must be accepted.",
+      ),
   });
 
   const initialValues = {
@@ -188,14 +190,11 @@ const CreateCardholderForm = ({
                 <MenuItem value="US">United States</MenuItem>
               </Field>
             </Grid>
-            {errorText !== "" && (
-              <Grid item xs={12}>
-                <Alert severity="error">{errorText}</Alert>
-              </Grid>
-            )}
             <Grid item xs={12}>
-              <FormControlLabel
-                control={<Field as={Checkbox} name="accept" />}
+              <Field
+                type="checkbox"
+                as={FormControlLabel}
+                control={<Checkbox />}
                 label={
                   <Typography variant="body2">
                     This cardholder has agreed to the{" "}
@@ -208,8 +207,16 @@ const CreateCardholderForm = ({
                     </Link>
                   </Typography>
                 }
+                name="accept"
+                error={touched.accept && Boolean(errors.accept)}
+                helperText={touched.accept && errors.accept}
               />
             </Grid>
+            {errorText !== "" && (
+              <Grid item xs={12}>
+                <Alert severity="error">{errorText}</Alert>
+              </Grid>
+            )}
           </Grid>
         </Form>
       )}
@@ -234,6 +241,7 @@ const CardholderCreateWidget = () => {
         state: faker.location.state(),
         postalCode: faker.location.zipCode("#####"),
         country: "US",
+        accept: true,
       });
     }
   };

--- a/src/sections/test-data/test-data-create-received-credit.tsx
+++ b/src/sections/test-data/test-data-create-received-credit.tsx
@@ -1,70 +1,66 @@
-import {
-  Alert,
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Divider,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Alert, Box, Button, Stack, Typography } from "@mui/material";
+import { useRouter } from "next/router";
 import React, { useState } from "react";
 
-import { fetchApi } from "src/utils/api-helpers";
+import {
+  extractJsonFromResponse,
+  handleResult,
+  postApi,
+} from "src/utils/api-helpers";
 
 const TestDataCreateReceivedCredit = () => {
-  const [submitted, setSubmitted] = useState(false);
+  const router = useRouter();
+
+  const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState("");
 
   const simulateReceivedCredit = async () => {
-    try {
-      setSubmitted(true);
-      const response = await fetchApi("api/create_receivedcredit");
-      if (!response.ok) {
-        const data = await response.json();
-        setErrorText(data.error);
-      }
-    } catch (error) {
-      setErrorText("Something went wrong");
-    } finally {
-      setSubmitted(false);
-    }
+    setSubmitting(true);
+    const response = await postApi("api/create_receivedcredit");
+    const result = await extractJsonFromResponse(response);
+    handleResult({
+      result,
+      onSuccess: () => {
+        router.reload();
+      },
+      onError: (error) => {
+        setErrorText(`Error: ${error.message}`);
+      },
+      onFinally: () => {
+        setSubmitting(false);
+      },
+    });
   };
 
   return (
-    <Card>
-      <CardHeader title="Simulate Received Credit"></CardHeader>
-      <CardContent sx={{ pt: 0 }}>
-        <Stack spacing={1}>
-          <Typography>
-            By pressing the Create Received Credit button, you will simulate
-            receiving a transfer into your Financial Account.
-          </Typography>
-          <Typography>
-            You can send funds directly to your Financial Account via ACH or
-            Wire Transfers by using its Account and Routing numbers.
-          </Typography>
-          <Typography>
-            Your Financial Account will receive $ 500.00 each time you press the
-            button.
-          </Typography>
-          {errorText !== "" && <Alert severity="error">{errorText}</Alert>}
-        </Stack>
-      </CardContent>
-      <Divider />
-      <CardActions sx={{ justifyContent: "center" }}>
+    <Stack spacing={1}>
+      <Typography variant="body2">
+        By pressing the &quot;Simulate Received Credit&quot; button, you will
+        simulate receiving a transfer into your Financial Account by creating a
+        testmode received credit.
+      </Typography>
+      <Typography variant="body2">
+        You can send funds directly to your Financial Account via ACH or Wire
+        Transfers by using its Account and Routing numbers.
+      </Typography>
+      <Typography variant="body2">
+        Your Financial Account will receive $500.00 each time you press the
+        button.
+      </Typography>
+      {errorText !== "" && <Alert severity="error">{errorText}</Alert>}
+      <Box pt={1}>
         <Button
           variant="contained"
           color="primary"
           size="large"
-          disabled={submitted}
+          disabled={submitting}
           onClick={simulateReceivedCredit}
+          fullWidth
         >
-          {submitted ? "Simulating..." : "Simulate Received Credit"}
+          {submitting ? "Simulating..." : "Simulate Received Credit"}
         </Button>
-      </CardActions>
-    </Card>
+      </Box>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
* Moves the simulate received credit button to the FA and overview pages
* Removes the settings page until we have something we need to put there
* Fixes the title for all pages
* Updates cookie notice wording
* Fixes the cardholder TOS acceptance not being enforced
* Tweaks side-nav demo notice at the bottom left