### PR TITLE
Add close button to floating test panel and update disclosures

### DIFF
--- a/src/components/floating-test-panel.tsx
+++ b/src/components/floating-test-panel.tsx
@@ -1,7 +1,14 @@
 import { PlusCircleIcon } from "@heroicons/react/20/solid";
-import { Button, Drawer, Stack, SvgIcon } from "@mui/material";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+import {
+  Button,
+  DialogTitle,
+  Drawer,
+  IconButton,
+  SvgIcon,
+  Typography,
+} from "@mui/material";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import useTheme from "@mui/system/useTheme";
 import React, { ReactNode } from "react";
 
@@ -41,12 +48,23 @@ const FloatingTestPanel = ({
         Generate Test Data
       </Button>
       <Drawer anchor="right" open={open} onClose={() => setOpen(false)}>
-        <Stack spacing={3} maxWidth={400} p={3}>
-          <Typography variant="h6" fontWeight={600}>
-            {title}
-          </Typography>
+        <DialogTitle
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          ml={1}
+          mt={1}
+        >
+          {title}
+          <IconButton onClick={() => setOpen(false)}>
+            <SvgIcon>
+              <XMarkIcon />
+            </SvgIcon>
+          </IconButton>
+        </DialogTitle>
+        <Box maxWidth={400} px={4}>
           {children}
-        </Stack>
+        </Box>
       </Drawer>
     </Box>
   );

--- a/src/layouts/dashboard/account-popover.tsx
+++ b/src/layouts/dashboard/account-popover.tsx
@@ -86,8 +86,8 @@ export const AccountPopover = ({
               target="_blank"
               underline="none"
             >
-              {session.accountId}
-              <SvgIcon sx={{ ml: 1, width: "20px", height: "20px" }}>
+              {session.accountId}{" "}
+              <SvgIcon fontSize="small" sx={{ verticalAlign: "top" }}>
                 <ArrowTopRightOnSquareIcon />
               </SvgIcon>
             </Link>

--- a/src/layouts/dashboard/layout.tsx
+++ b/src/layouts/dashboard/layout.tsx
@@ -59,9 +59,9 @@ const Layout = ({ children }: { children: ReactNode }) => {
               <Typography variant="body2" color="neutral.400">
                 Stripe Issuing & Treasury Platform Demo partners with Stripe
                 Payments Company for money transmission services and account
-                services with funds held at Evolve Bank & Trust, Member FDIC.
-                Stripe Issuing & Treasury Platform Demo Visa® Commercial Credit
-                cards are issued by Celtic Bank.
+                services with funds held at Example Bank, Member FDIC. Stripe
+                Issuing & Treasury Platform Demo Visa® Commercial Credit cards
+                are issued by Example Bank.
               </Typography>
             </Box>
           </Box>

--- a/src/layouts/dashboard/side-nav.tsx
+++ b/src/layouts/dashboard/side-nav.tsx
@@ -91,6 +91,7 @@ export const SideNav = (props: { onClose: () => void; open: boolean }) => {
           </Stack>
         </Box>
         <Divider sx={{ borderColor: "neutral.700" }} />
+        {/* FOR-DEMO-ONLY: You can remove this for an actual application */}
         <Box
           sx={{
             px: 2,
@@ -100,6 +101,10 @@ export const SideNav = (props: { onClose: () => void; open: boolean }) => {
         >
           <Typography color="neutral.100" variant="subtitle2">
             Stripe Issuing & Treasury Demo
+          </Typography>
+          <Typography color="neutral.600" variant="subtitle2">
+            Data shown, including cards and transactions, is for testing
+            purposes only. No content reflects actual financial activity.
           </Typography>
           <Button
             component="a"

--- a/src/pages/cards/[cardId].tsx
+++ b/src/pages/cards/[cardId].tsx
@@ -176,15 +176,8 @@ const GenerateTestDataDrawer = ({ cardId }: { cardId: string }) => {
           target="_blank"
           underline="none"
         >
-          going to this card&apos;s overview in the Stripe dashboard
-          <SvgIcon
-            sx={{
-              ml: 0.5,
-              width: "20px",
-              height: "20px",
-              verticalAlign: "middle",
-            }}
-          >
+          going to this card&apos;s overview in the Stripe dashboard{" "}
+          <SvgIcon fontSize="small" sx={{ verticalAlign: "top" }}>
             <ArrowTopRightOnSquareIcon />
           </SvgIcon>
         </Link>{" "}

--- a/src/pages/onboard.tsx
+++ b/src/pages/onboard.tsx
@@ -218,15 +218,8 @@ const ConnectOnboardingGuideDialog = ({
             target="_blank"
             underline="none"
           >
-            here
-            <SvgIcon
-              sx={{
-                ml: 0.5,
-                width: "20px",
-                height: "20px",
-                verticalAlign: "top",
-              }}
-            >
+            here{" "}
+            <SvgIcon fontSize="small" sx={{ verticalAlign: "top" }}>
               <ArrowTopRightOnSquareIcon />
             </SvgIcon>
           </Link>

--- a/src/sections/cardholders/cardholder-create-widget.tsx
+++ b/src/sections/cardholders/cardholder-create-widget.tsx
@@ -199,11 +199,11 @@ const CreateCardholderForm = ({
                   <Typography variant="body2">
                     This cardholder has agreed to the{" "}
                     <Link href="https://stripe.com/legal/issuing/celtic-authorized-user-terms">
-                      Celtic Bank Authorized User Terms
+                      Example Bank Authorized User Terms
                     </Link>{" "}
                     and{" "}
                     <Link href="https://www.celticbank.com/privacy">
-                      Celtic Bank Privacy Policy.
+                      Example Bank Privacy Policy.
                     </Link>
                   </Typography>
                 }

--- a/src/sections/cardholders/cardholder-update-widget.tsx
+++ b/src/sections/cardholders/cardholder-update-widget.tsx
@@ -97,11 +97,11 @@ const CardholderUpdateWidget = ({ cardholderId }: { cardholderId: string }) => {
                         <Typography variant="body2">
                           This cardholder has agreed to the{" "}
                           <Link href="https://stripe.com/legal/issuing/celtic-authorized-user-terms">
-                            Celtic Bank Authorized User Terms
+                            Example Bank Authorized User Terms
                           </Link>{" "}
                           and{" "}
                           <Link href="https://www.celticbank.com/privacy">
-                            Celtic Bank Privacy Policy.
+                            Example Bank Privacy Policy.
                           </Link>
                         </Typography>
                       }

--- a/src/sections/financial-account/send-money-wizard-dialog.tsx
+++ b/src/sections/financial-account/send-money-wizard-dialog.tsx
@@ -528,11 +528,11 @@ const ConfirmingTransferForm = ({
                     href="https://stripe.com/docs/api/treasury/outbound_payments/test_mode_fail"
                     underline="none"
                   >
-                    docs
-                  </Link>{" "}
-                  <SvgIcon fontSize="small" sx={{ color: "neutral.500" }}>
-                    <ArrowTopRightOnSquareIcon />
-                  </SvgIcon>
+                    docs{" "}
+                    <SvgIcon fontSize="small" sx={{ verticalAlign: "top" }}>
+                      <ArrowTopRightOnSquareIcon />
+                    </SvgIcon>
+                  </Link>
                   )
                 </Alert>
               </Box>

--- a/src/sections/test-data/test-data-create-received-credit.tsx
+++ b/src/sections/test-data/test-data-create-received-credit.tsx
@@ -33,22 +33,24 @@ const TestDataCreateReceivedCredit = () => {
   };
 
   return (
-    <Stack spacing={1}>
-      <Typography variant="body2">
-        By pressing the &quot;Simulate Received Credit&quot; button, you will
-        simulate receiving a transfer into your Financial Account by creating a
-        testmode received credit.
-      </Typography>
-      <Typography variant="body2">
-        You can send funds directly to your Financial Account via ACH or Wire
-        Transfers by using its Account and Routing numbers.
-      </Typography>
-      <Typography variant="body2">
-        Your Financial Account will receive $500.00 each time you press the
-        button.
-      </Typography>
-      {errorText !== "" && <Alert severity="error">{errorText}</Alert>}
-      <Box pt={1}>
+    <>
+      <Stack spacing={1}>
+        <Typography variant="body2">
+          By pressing the &quot;Simulate Received Credit&quot; button, you will
+          simulate receiving a transfer into your Financial Account by creating
+          a testmode received credit.
+        </Typography>
+        <Typography variant="body2">
+          You can send funds directly to your Financial Account via ACH or Wire
+          Transfers by using its Account and Routing numbers.
+        </Typography>
+        <Typography variant="body2">
+          Your Financial Account will receive $500.00 each time you press the
+          button.
+        </Typography>
+        {errorText !== "" && <Alert severity="error">{errorText}</Alert>}
+      </Stack>
+      <Box mt={3}>
         <Button
           variant="contained"
           color="primary"
@@ -60,7 +62,7 @@ const TestDataCreateReceivedCredit = () => {
           {submitting ? "Simulating..." : "Simulate Received Credit"}
         </Button>
       </Box>
-    </Stack>
+    </>
   );
 };
 


### PR DESCRIPTION
* Adds a close button to the floating test panel so that it can be closed on mobile
* Fixes alignment of the arrow icon used to denote a link that'll open in a new tab
* Adds a disclaimer about no actual financial activity to the bottom left
* Updates disclosures and ToS to be bank agnostic