### PR TITLE
Tweak bank terms link to be an example instead of real

### DIFF
--- a/src/sections/cardholders/cardholder-create-widget.tsx
+++ b/src/sections/cardholders/cardholder-create-widget.tsx
@@ -198,13 +198,8 @@ const CreateCardholderForm = ({
                 label={
                   <Typography variant="body2">
                     This cardholder has agreed to the{" "}
-                    <Link href="https://stripe.com/legal/issuing/celtic-authorized-user-terms">
-                      Example Bank Authorized User Terms
-                    </Link>{" "}
-                    and{" "}
-                    <Link href="https://www.celticbank.com/privacy">
-                      Example Bank Privacy Policy.
-                    </Link>
+                    <Link href="#">Example Bank Authorized User Terms</Link> and{" "}
+                    <Link href="#">Example Bank Privacy Policy.</Link>
                   </Typography>
                 }
                 name="accept"


### PR DESCRIPTION
* Tweaks the bank terms link for Cardholder ToS to be an example instead of real

Note: Real production implementations of the sample app needs to fill these URLs with proper ones pointing to the appropriate bank terms