### PR TITLE
Tweak Render environment variable ordering

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,9 +15,9 @@ services:
       fromDatabase:
         name: issuing-treasury-db
         property: connectionString
-    - key: STRIPE_SECRET_KEY
-      sync: false
     - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+      sync: false
+    - key: STRIPE_SECRET_KEY
       sync: false
     - key: NEXTAUTH_SECRET
       generateValue: true


### PR DESCRIPTION
* Shows the publishable key at the top when prompted to match what people see on the Stripe dashboard

<img width="1304" alt="image" src="https://github.com/stripe-samples/issuing-treasury/assets/103917180/f21edf4b-5ad3-457b-803e-51438368f951">
