### PR TITLE
Add `Content-Security-Policy` security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,52 @@
+const isDevelopment = process.env.NODE_ENV === "development";
+
+// We are setting the CSP headers as strictly as possible. There are a few notable exceptions being made:
+// - We are allowing 'unsafe-eval' in the script-src directive in development only because we are using Next.js'
+//   built-in support for React Fast Refresh. This is a temporary exception until Next.js supports a better
+//   solution for Fast Refresh.
+// - We are allowing 'unsafe-inline' in the style-src directive. This is a temporary exception until Next.js
+//   supports a better solution.
+// - We are allowing fonts.gstatic.com and fonts.googleapis.com in the font-src directive. We could host the
+//   fonts ourselves, but it's easier to use Google Fonts and the risk is minimal. Feel free to host the fonts
+//   yourself if you prefer and tighten up the font-src and style-src directives.
+// - We are allowing js.stripe.com in the frame-src directive. This is required for Stripe Issuing Elements to work.
+//
+// Learn more about CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+// Learn more about Next.js security headers: https://nextjs.org/docs/pages/api-reference/next-config-js/headers#content-security-policy
+//
+// Also follow [this discussion](https://github.com/vercel/next.js/discussions/41473) about making Next.js have a
+// strict CSP implementation which would make it easier to tighten these directives with a `nonce`.
+const ContentSecurityPolicy = `
+  default-src 'none';
+  base-uri 'none';
+  connect-src 'self';
+  font-src 'self' fonts.gstatic.com;
+  form-action 'self';
+  frame-ancestors 'none';
+  frame-src js.stripe.com;
+  img-src 'self';
+  script-src 'self' js.stripe.com ${isDevelopment ? "'unsafe-eval'" : ""};
+  style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+  upgrade-insecure-requests;
+`;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  swcMinify: true,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: ContentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/sections/overview/transaction-flow-details.tsx
+++ b/src/sections/overview/transaction-flow-details.tsx
@@ -22,7 +22,7 @@ const TransactionFlowDetails = ({
     <Stack direction="row" spacing={1}>
       <Typography variant="body2">{flowTypeFormatted}</Typography>
       <Link href={flowDetails.hosted_regulatory_receipt_url} target="_blank">
-        <SvgIcon>
+        <SvgIcon fontSize="small" sx={{ verticalAlign: "top" }}>
           <DocumentArrowDownIcon />
         </SvgIcon>
       </Link>


### PR DESCRIPTION
* Adds `Content-Security-Policy` security headers
* Fixes alignment issue with the transaction flow details icon

We are setting the content security policy as strictly as possible. There are a few notable exceptions being made:
- We are allowing 'unsafe-eval' in the script-src directive in development only because we are using Next.js' built-in support for React Fast Refresh. This is a temporary exception until Next.js supports a better solution for Fast Refresh.
- We are allowing 'unsafe-inline' in the style-src directive. This is a temporary exception until Next.js supports a better solution. [The risk of keeping this is minimal](https://scotthelme.co.uk/can-you-get-pwned-with-css/) and we'll keep it until there's broader support in the community.
- We are allowing fonts.gstatic.com and fonts.googleapis.com in the font-src directive. We could host the fonts ourselves, but it's easier to use Google Fonts and the risk is minimal. Feel free to host the fonts yourself if you prefer and tighten up the font-src and style-src directives.
- We are allowing js.stripe.com in the frame-src directive. This is required for Stripe Issuing Elements to work.

Learn more about CSP: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
Learn more about Next.js security headers: https://nextjs.org/docs/pages/api-reference/next-config-js/headers#content-security-policy

Also follow [this discussion](https://github.com/vercel/next.js/discussions/41473) about making Next.js have a strict CSP implementation which would make it easier to tighten these directives with a `nonce`.

Additional helpful links during my research:
* https://reesmorris.co.uk/blog/implementing-proper-csp-nextjs-styled-components
* https://stackoverflow.com/questions/65551212/using-csp-in-nextjs-nginx-and-material-uissr
* https://securityheaders.com/