### PR TITLE
Set the starter application name for analytics

### DIFF
--- a/src/utils/stripe-loader.ts
+++ b/src/utils/stripe-loader.ts
@@ -1,6 +1,7 @@
 import { Stripe } from "stripe";
 
 const API_VERSION = "2023-08-16";
+const APP_INFO_NAME = "Stripe Issuing & Treasury Starter Application";
 
 const stripeClient = () => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
@@ -13,6 +14,8 @@ const stripeClient = () => {
 
   return new Stripe(stripeSecretKey, {
     apiVersion: API_VERSION,
+    typescript: true,
+    appInfo: { name: APP_INFO_NAME },
   });
 };
 


### PR DESCRIPTION
- Sets the app info on the Stripe backend client in order to run analytics