### PR TITLE
Remove `NEXTAUTH_URL` from local development steps as it is only needed for production

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,8 +13,8 @@ CONNECT_ONBOARDING_REDIRECT_URL="http://localhost:3000"
 
 # You can generate this using `openssl rand -base64 32`
 NEXTAUTH_SECRET=""
-# Your NextAuth base URL
-NEXTAUTH_URL="http://localhost:3000"
+# Your NextAuth base URL. Set this up for production deployments.
+# NEXTAUTH_URL="http://localhost:3000"
 
 ### Demo configuration
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Update `.env.local` to reflect:
 - **NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY**: Your Stripe publishable key
 - **STRIPE_SECRET_KEY**: Your Stripe private key
 - **NEXTAUTH_SECRET**: For JWT encryption by NextAuth.js ([learn more](https://next-auth.js.org/configuration/options#nextauth_secret)). Use `openssl rand -base64 32` to obtain a new one
-- **NEXTAUTH_URL**: Your application URL, for local use you can keep the default "<http://localhost:3000>"
 - **CONNECT_ONBOARDING_REDIRECT_URL**: Your application URL, for local use you can keep the default "<http://localhost:3000>"
 
 ### Database setup


### PR DESCRIPTION
- Removes the `NEXTAUTH_URL` environment variable setup from local development and README steps as it is only needed for production