### PR TITLE
Display decline reason for declined auths on auth details page and update `account_holder_type` to "company"

### DIFF
--- a/src/pages/api/send_money.ts
+++ b/src/pages/api/send_money.ts
@@ -32,7 +32,7 @@ const sendMoney = async (req: NextApiRequest, res: NextApiResponse) => {
   );
   const financialAccount = financialAccounts.data[0];
 
-  /* The following example uses a hardcoded values for demo mode */
+  /* The following example uses hardcoded values for demo mode */
 
   let city, state, postal_code, line1;
 
@@ -59,7 +59,7 @@ const sendMoney = async (req: NextApiRequest, res: NextApiResponse) => {
       destination_payment_method_data: {
         type: "us_bank_account",
         us_bank_account: {
-          account_holder_type: "individual",
+          account_holder_type: "company",
           routing_number: "110000000",
           account_number: "000000000009",
         },

--- a/src/pages/authorizations/[authorizationId].tsx
+++ b/src/pages/authorizations/[authorizationId].tsx
@@ -55,6 +55,8 @@ const Page = ({
 }: {
   authorization: Stripe.Issuing.Authorization;
 }) => {
+  const declineReason = authorization.request_history.at(-1)?.reason;
+
   return (
     <Box
       component="main"
@@ -147,6 +149,16 @@ const Page = ({
                   </Typography>
                 </Box>
               </Grid>
+              {!authorization.approved && declineReason && (
+                <Grid item xs={12} sm={6} md={4}>
+                  <Typography variant="subtitle2">Decline reason</Typography>
+                  <Box sx={{ mt: 0.5 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      {titleize(declineReason.replace(/_/g, " "))}
+                    </Typography>
+                  </Box>
+                </Grid>
+              )}
             </Grid>
           </CardContent>
         </Card>


### PR DESCRIPTION
This adds the decline reason for declined auths on the auth details page (see [tracking spreadsheet](https://docs.google.com/spreadsheets/d/1-IkJ_CiUINMXAC_lEHujUQeWCONS8cufBCgoi86V0Cg/edit#gid=0&range=B19)). For non-declined auths, we won't show a decline reason.

Declined auth details page:
<img width="1530" alt="Screenshot 2023-09-18 at 6 44 35 PM" src="https://github.com/stripe-samples/issuing-treasury/assets/97252502/0ad8989a-dc9d-4700-96cf-1f0063e1404f">

Approved auth details page:
<img width="1488" alt="Screenshot 2023-09-18 at 6 44 45 PM" src="https://github.com/stripe-samples/issuing-treasury/assets/97252502/da3f66c0-c7e3-42c3-8d59-95130bc696f9">

This also updates the `account_holder_type` to "company" for outbound payments, per https://docs.google.com/document/d/1Elfsh36muNpqbq0Qjzztc4IfnHiQaYv59wt9rLEGtTg/edit?disco=AAAA4rgP5To
