### PR TITLE
Expense management sample 8: Localize payouts to external accounts

### DIFF
--- a/src/pages/api/add_external_account.ts
+++ b/src/pages/api/add_external_account.ts
@@ -85,10 +85,17 @@ const addExternalAccount = async (
   const stripe = stripeClient(platform);
 
   let token;
+  // If the user has a Treasury Financial Account (as is enabled for embedded
+  // finance platforms), then use that as a payout[0] destination. Otherwise,
+  // add a (fake) external bank account, which in a real livemode deployment
+  // would be provided by the user. When the user requests a payout from their
+  // balance, the funds will be sent to whatever account is set here.
+  //
+  // [0] https://stripe.com/docs/payouts
   if (useCase == UseCase.EmbeddedFinance) {
     token = await addExternalFinancialAccount(stripeAccount, country, currency);
   } else {
-    token = await addExternalBankAccount(accountId, currency);
+    token = await addExternalBankAccount(stripeAccount, currency);
   }
 
   await stripe.accounts.createExternalAccount(accountId, {

--- a/src/pages/api/create_paymentlink.ts
+++ b/src/pages/api/create_paymentlink.ts
@@ -12,7 +12,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) =>
 
 const createPaymentLink = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSessionForServerSide(req, res);
-  const { stripeAccount } = session;
+  const { stripeAccount, currency } = session;
   const { accountId, platform } = stripeAccount;
   const stripe = stripeClient(platform);
 
@@ -32,7 +32,7 @@ const createPaymentLink = async (req: NextApiRequest, res: NextApiResponse) => {
       ? await stripe.prices.create(
           {
             unit_amount: 1000,
-            currency: "usd",
+            currency: currency,
             product_data: {
               name: "Some Product",
             },

--- a/src/pages/api/create_payout.ts
+++ b/src/pages/api/create_payout.ts
@@ -13,7 +13,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) =>
 
 const createPayout = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSessionForServerSide(req, res);
-  const { stripeAccount } = session;
+  const { stripeAccount, currency } = session;
   const { accountId, platform } = stripeAccount;
   const stripe = stripeClient(platform);
 
@@ -50,7 +50,7 @@ const createPayout = async (req: NextApiRequest, res: NextApiResponse) => {
   await stripe.payouts.create(
     {
       amount: availableBalance,
-      currency: "usd",
+      currency: currency,
     },
     { stripeAccount: accountId },
   );

--- a/src/pages/test-data.tsx
+++ b/src/pages/test-data.tsx
@@ -5,6 +5,8 @@ import React, { ReactNode } from "react";
 import DashboardLayout from "src/layouts/dashboard/layout";
 import TestDataCreatePaymentLink from "src/sections/test-data/test-data-create-payment-link";
 import TestDataCreatePayouts from "src/sections/test-data/test-data-create-payout";
+import TestDataCreatePayoutsToBank from "src/sections/test-data/test-data-create-payout-to-bank";
+import UseCase from "src/types/use_cases";
 import { getSessionForServerSideProps } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 
@@ -12,7 +14,7 @@ export const getServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
   const session = await getSessionForServerSideProps(context);
-  const { stripeAccount } = session;
+  const { stripeAccount, useCase } = session;
   const { accountId, platform } = stripeAccount;
   const stripe = stripeClient(platform);
   const responseAccount = await stripe.accounts.retrieve(accountId);
@@ -23,17 +25,23 @@ export const getServerSideProps = async (
   const responseBalance = await stripe.balance.retrieve({
     stripeAccount: accountId,
   });
-  const availableBalance = responseBalance.available[0].amount;
 
-  return { props: { hasExternalAccount, availableBalance } };
+  const availableBalance = responseBalance.available[0].amount;
+  const currency = responseBalance.available[0].currency;
+
+  return { props: { hasExternalAccount, availableBalance, currency, useCase } };
 };
 
 const Page = ({
   hasExternalAccount,
   availableBalance,
+  currency,
+  useCase,
 }: {
   hasExternalAccount: boolean;
   availableBalance: number;
+  currency: string;
+  useCase: UseCase;
 }) => {
   return (
     <>
@@ -50,10 +58,19 @@ const Page = ({
               <TestDataCreatePaymentLink />
             </Grid>
             <Grid item xs={12} sm={10} md={8}>
-              <TestDataCreatePayouts
-                hasExternalAccount={hasExternalAccount}
-                availableBalance={availableBalance}
-              />
+              {useCase == UseCase.EmbeddedFinance ? (
+                <TestDataCreatePayouts
+                  hasExternalAccount={hasExternalAccount}
+                  availableBalance={availableBalance}
+                  currency={currency}
+                />
+              ) : (
+                <TestDataCreatePayoutsToBank
+                  hasExternalAccount={hasExternalAccount}
+                  availableBalance={availableBalance}
+                  currency={currency}
+                />
+              )}
             </Grid>
           </Grid>
         </Container>

--- a/src/sections/test-data/test-data-create-payout-to-bank.tsx
+++ b/src/sections/test-data/test-data-create-payout-to-bank.tsx
@@ -19,7 +19,7 @@ import {
 } from "src/utils/api-helpers";
 import { currencyFormat } from "src/utils/format";
 
-function TestDataCreatePayout({
+function TestDataCreatePayoutsToBank({
   availableBalance: availableBalanceProp,
   hasExternalAccount: hasExternalAccountProp,
   currency: currencyProp,
@@ -79,19 +79,19 @@ function TestDataCreatePayout({
       <CardContent sx={{ pt: 0 }}>
         <Stack spacing={1}>
           <Typography>
-            In order to enable payouts, you need to set your financial account
-            as the external account for your connected account.
+            In order to enable payouts, you need to attach a bank account as the
+            external account for your connected account.
           </Typography>
           <Typography>
-            {`If you haven't done it yet, by pressing the "Add financial
-          account as external account" button, the financial account will be set
-          as an external account, and manual payouts will be enabled.`}
+            {`If you haven't done it yet, by pressing the "Add bank account
+            as external account" button, a test bank account will be set as
+            an external account, and manual payouts will be enabled.`}
           </Typography>
           <Typography>
             Platforms have the ability to set up automatic payouts with
             different schedules. You can dive deep into this topic on{" "}
             <Link
-              href="https://stripe.com/docs/treasury/moving-money/payouts"
+              href="https://stripe.com/docs/connect/manage-payout-schedule"
               target="_blank"
               underline="none"
             >
@@ -141,9 +141,7 @@ function TestDataCreatePayout({
             onClick={addExternalAccount}
             disabled={submitting}
           >
-            {submitting
-              ? "Adding..."
-              : "Add financial account as external account"}
+            {submitting ? "Adding..." : "Add bank account as external account"}
           </Button>
         )}
       </CardActions>
@@ -151,4 +149,4 @@ function TestDataCreatePayout({
   );
 }
 
-export default TestDataCreatePayout;
+export default TestDataCreatePayoutsToBank;


### PR DESCRIPTION
Localizes the experience for paying out outstanding balances to external accounts, and adapts it for expense management use cases (i.e. setups that do not pay out to a Treasury financial account)