### PR TITLE
Fix login loop for registered accounts on prod builds

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,6 +64,6 @@ export const config = {
      * - assets (images, fonts, etc.)
      * - (auth|api)/register (registration page)
      */
-    "/((?!_next/static|_next/image|favicon.ico|assets|auth/register|api/register).*)",
+    "/((?!_next/static|_next/image|favicon.ico|assets|auth/register|api/register|auth/login).*)",
   ],
 };


### PR DESCRIPTION
I noticed this obscure-ish bug while reading ~~copying~~ some of the code. 

## Bug

1. Register an account and log out of dashboard
2. Visit https://baas.stripe.dev/
3. You should be redirected to `https://baas.stripe.dev/auth/login?callbackUrl=%2F` 
4. Try to login with the credentials
5. Get stuck in a login loop 

![CleanShot 2024-01-19 at 14 47 21@2x](https://github.com/stripe-samples/issuing-treasury/assets/116756196/c1418c7b-f112-4bf9-952d-29c5c9360f4c)

For whatever reason, the bug only exists on prod builds, so not reproducible with `next dev`, but `next build && next start` will make it reproducible locally. In my own application, I applied this fix and it worked.