### PR TITLE
Revert removing requesting card_payments

### DIFF
--- a/_base/src/pages/api/register.ts
+++ b/_base/src/pages/api/register.ts
@@ -69,6 +69,10 @@ const register = async (req: NextApiRequest, res: NextApiResponse) => {
     }),
     capabilities: {
       transfers: { requested: true },
+      // `card_payments` is only requested for the Test Data section to demonstrate payments and how it is a separate
+      // balance from the Issuing balance or Treasury Financial Account balance. It is not required for Issuing or
+      // Treasury.
+      card_payments: { requested: true },
       card_issuing: { requested: true },
       // @if financialProduct==embedded-finance
       // If we are creating an user an embedded finance platform, we must request

--- a/_base/src/sections/overview/overview-payments-balance.tsx
+++ b/_base/src/sections/overview/overview-payments-balance.tsx
@@ -23,12 +23,14 @@ export const OverviewAvailableBalance = (props: {
         >
           <Stack spacing={1}>
             <Typography color="text.secondary" variant="overline">
-              Payments Available Balance
+              Payments Acquired Balance
             </Typography>
             <Typography variant="h4">
               {currencyFormat(value / 100, currency)}
             </Typography>
-            <Typography color="text.secondary">Available balance</Typography>
+            <Typography color="text.secondary">
+              Available acquired balance
+            </Typography>
           </Stack>
           <Avatar
             sx={{

--- a/embedded-finance/src/pages/api/register.ts
+++ b/embedded-finance/src/pages/api/register.ts
@@ -61,6 +61,10 @@ const register = async (req: NextApiRequest, res: NextApiResponse) => {
     }),
     capabilities: {
       transfers: { requested: true },
+      // `card_payments` is only requested for the Test Data section to demonstrate payments and how it is a separate
+      // balance from the Issuing balance or Treasury Financial Account balance. It is not required for Issuing or
+      // Treasury.
+      card_payments: { requested: true },
       card_issuing: { requested: true },
       // If we are creating an user an embedded finance platform, we must request
       // the `treasury` capability in order to create a FinancialAccount for them

--- a/expense-management/src/pages/api/register.ts
+++ b/expense-management/src/pages/api/register.ts
@@ -61,6 +61,10 @@ const register = async (req: NextApiRequest, res: NextApiResponse) => {
     }),
     capabilities: {
       transfers: { requested: true },
+      // `card_payments` is only requested for the Test Data section to demonstrate payments and how it is a separate
+      // balance from the Issuing balance or Treasury Financial Account balance. It is not required for Issuing or
+      // Treasury.
+      card_payments: { requested: true },
       card_issuing: { requested: true },
     },
   });

--- a/expense-management/src/sections/overview/overview-payments-balance.tsx
+++ b/expense-management/src/sections/overview/overview-payments-balance.tsx
@@ -22,12 +22,14 @@ export const OverviewAvailableBalance = (props: {
         >
           <Stack spacing={1}>
             <Typography color="text.secondary" variant="overline">
-              Payments Available Balance
+              Payments Acquired Balance
             </Typography>
             <Typography variant="h4">
               {currencyFormat(value / 100, currency)}
             </Typography>
-            <Typography color="text.secondary">Available balance</Typography>
+            <Typography color="text.secondary">
+              Available acquired balance
+            </Typography>
           </Stack>
           <Avatar
             sx={{


### PR DESCRIPTION
- Related to https://github.com/stripe-samples/issuing-treasury/issues/298. Reverts removing requesting of `card_payments` for now. In the future, we'll move requesting from the register flow to come later when someone goes and clicks on "Enable Payments" or something in the current "Test Data" section.
- After this deploys, I'll manually request the `card_payments` capability for all the existing users that don't have it.