### PR TITLE
Fix render yaml not being in the root

### DIFF
--- a/_base/README.md
+++ b/_base/README.md
@@ -35,6 +35,7 @@ For details of more features see the [Issuing and Treasury sample app documentat
 - Obtain your Stripe API keys at <https://dashboard.stripe.com/test/apikeys>
 
 ## Deploy the sample app to the cloud
+
 You can immediately deploy this sample app to a unique, public URL with no coding required. Choose from Vercel or Render by clicking a button below:
 
 ### Deploy the web application on Vercel

--- a/render.yaml
+++ b/render.yaml
@@ -16,22 +16,28 @@ services:
   envVars:
     - key: PORT
       value: 10000
-    - key: DATABASE_URL
+    - key: POSTGRES_URL
       fromDatabase:
         name: issuing-treasury-db
         property: connectionString
-    - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US
+    # This will default to the US region
+    - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
       sync: false
-    - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK
+    - key: STRIPE_SECRET_KEY
       sync: false
-    - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_EU
-      sync: false
-    - key: STRIPE_SECRET_KEY_US
-      sync: false
-    - key: STRIPE_SECRET_KEY_UK
-      sync: false
-    - key: STRIPE_SECRET_KEY_EU
-      sync: false
+    # You can enable these and comment out the above keys if you want to try the multi-region deployment
+    # - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US
+    #   sync: false
+    # - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK
+    #   sync: false
+    # - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_EU
+    #   sync: false
+    # - key: STRIPE_SECRET_KEY_US
+    #   sync: false
+    # - key: STRIPE_SECRET_KEY_UK
+    #   sync: false
+    # - key: STRIPE_SECRET_KEY_EU
+    #   sync: false
     - key: NEXTAUTH_SECRET
       generateValue: true
 

--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,9 @@ previewsEnabled: false
 services:
 - type: web
   name: issuing-treasury
-  env: node
+  runtime: node
   plan: free
+  rootDir: _base
   buildCommand: npm install; npx prisma migrate deploy; npx prisma generate; npm run build;
   # If you plan to have your own custom domain, you can remove these environment variables being assigned here and
   # assign them to your custom domain values through the Render.com dashboard once this web service has been provisioned


### PR DESCRIPTION
- Fixes [#342](https://github.com/stripe-samples/issuing-treasury/issues/342)
- Simplifies the Render deployment so that it only uses the default US region keys without a region suffix. The code to do it with multi-region on Render is still there but commented out.
- Fixes the `POSTGRES_URL`/`DATABASE_URL` environment variable being broken in the Render deployment