### PR TITLE
Rename references to the sample app to BaaS platform demo

### DIFF
--- a/_base/README.md
+++ b/_base/README.md
@@ -1,11 +1,11 @@
-# Stripe Issuing and Treasury: An Embedded Finance starter application
+# Stripe BaaS platform demo: An Embedded Finance starter application
 
-This sample demonstrates a basic web application with embedded finance features built on Stripe’s Issuing and Treasury APIs.
+This sample demonstrates a basic web application with multi-region embedded finance and expense management features built on Stripe's Issuing and Treasury APIs.
 
-**Note: this directory contains a demo application showcasing a wide range of Banking-as-a-Service products at Stripe. You can use it today at https://baas.stripe.dev. If you are beginning an integration with Stripe's Banking-as-a-Service APIs, we recommend you instead read and use sample application code that is focussed on the financial product you want to build. See the non-`_base` directories in the root of this repository.**
+**Note: this directory contains a demo application showcasing a wide range of Banking-as-a-Service products at Stripe. You can use it today at https://baas.stripe.dev. If you are beginning an integration with Stripe's Banking-as-a-Service APIs, we recommend you instead read and use sample application code that is focussed on the financial product you want to build. See the non-`_base` directories in the root of this repository (for example: `embedded-finance`, `expense-management`).**
 
 <p align="center">
-  <img width="715" alt="Issuing and Treasury sample app card details screenshot" src="https://github.com/stripe-samples/issuing-treasury/assets/103917180/5acecf09-d65d-499c-9171-eb187656dd2b" />
+  <img width="715" alt="BaaS platform demo card details screenshot" src="https://github.com/stripe-samples/issuing-treasury/assets/103917180/5acecf09-d65d-499c-9171-eb187656dd2b" />
 </p>
 
 ## Demo

--- a/_base/src/layouts/dashboard/layout.tsx
+++ b/_base/src/layouts/dashboard/layout.tsx
@@ -56,7 +56,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <>
       <Head>
-        <title>BaaS Platform Demo</title>
+        <title>Stripe BaaS platform demo</title>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
       <TopNav onNavOpen={() => setOpenNav(true)} />
@@ -71,11 +71,11 @@ const Layout = ({ children }: { children: ReactNode }) => {
                 // @end-exclude-from-subapps
                 // @if financialProduct==embedded-finance
                 <Typography variant="body2" color="neutral.400">
-                  Stripe Issuing and Treasury Platform Demo partners with Stripe
-                  Payments Company for money transmission services and account
-                  services with funds held at Example Bank, Member FDIC. Stripe
-                  Issuing and Treasury Platform Demo Visa® Commercial Credit
-                  cards are issued by Example Bank.{" "}
+                  Stripe BaaS platform demo partners with Stripe Payments
+                  Company for money transmission services and account services
+                  with funds held at Example Bank, Member FDIC. Stripe BaaS
+                  Platform Demo Visa® Commercial Credit cards are issued by
+                  Example Bank.{" "}
                   <Link
                     href="https://stripe.com/privacy"
                     target="_blank"
@@ -93,10 +93,10 @@ const Layout = ({ children }: { children: ReactNode }) => {
                 // @end-exclude-from-subapps
                 // @if financialProduct==expense-management
                 <Typography variant="body2" color="neutral.400">
-                  Stripe Issuing Platform Demo partners with Stripe Payments
+                  Stripe BaaS platform demo partners with Stripe Payments
                   Company for money transmission services and account services.
-                  Stripe Issuing Platform Demo Visa® Commercial Credit cards
-                  are issued by Example Bank.{" "}
+                  Stripe BaaS platform demo Visa® Commercial Credit cards are
+                  issued by Example Bank.{" "}
                   <Link
                     href="https://stripe.com/privacy"
                     target="_blank"

--- a/_base/src/layouts/dashboard/side-nav.tsx
+++ b/_base/src/layouts/dashboard/side-nav.tsx
@@ -130,33 +130,9 @@ export const SideNav = (props: { onClose: () => void; open: boolean }) => {
           }}
           textAlign="center"
         >
-          {/* @begin-exclude-from-subapps */}
-          {financialProduct === FinancialProduct.EmbeddedFinance && (
-            // @end-exclude-from-subapps
-            // @if financialProduct==embedded-finance
-            <>
-              <Typography color="neutral.100" variant="subtitle2">
-                Stripe Issuing and Treasury
-              </Typography>
-              <Typography color="neutral.100" variant="subtitle2">
-                platform demo
-              </Typography>
-            </>
-            // @endif
-            // @begin-exclude-from-subapps
-          )}
-          {/* @end-exclude-from-subapps */}
-          {/* @begin-exclude-from-subapps */}
-          {financialProduct === FinancialProduct.ExpenseManagement && (
-            // @end-exclude-from-subapps
-            // @if financialProduct==expense-management
-            <Typography color="neutral.100" variant="subtitle2">
-              Stripe Issuing platform demo
-            </Typography>
-            // @endif
-            // @begin-exclude-from-subapps
-          )}
-          {/* @end-exclude-from-subapps */}
+          <Typography color="neutral.100" variant="subtitle2">
+            Stripe BaaS platform demo
+          </Typography>
           <Typography color="neutral.600" variant="subtitle2">
             Data, financial activity and cards are fictitious and for testing
             purposes only. You should not input personal information.

--- a/_base/src/pages/_app.tsx
+++ b/_base/src/pages/_app.tsx
@@ -38,20 +38,17 @@ export default function App({
   return (
     <CacheProvider value={emotionCache}>
       <Head>
-        <title>Stripe Issuing and Treasury platform demo</title>
+        <title>Stripe BaaS platform demo</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://baas.stripe.dev" />
-        <meta
-          property="og:title"
-          content="Stripe Issuing and Treasury platform demo"
-        />
+        <meta property="og:title" content="Stripe BaaS platform demo" />
         <meta
           property="og:description"
-          content="This web app demonstrates Stripe Issuing and Treasury APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
+          content="This web app demonstrates Stripe Banking-as-a-Service APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
         />
         <meta
           property="og:image"
@@ -59,17 +56,14 @@ export default function App({
         />
         <meta
           property="og:image:alt"
-          content="Stripe Issuing and Treasury Platform Sample App Screenshot"
+          content="Stripe BaaS platform Sample App Screenshot"
         />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:url" content="https://baas.stripe.dev" />
-        <meta
-          name="twitter:title"
-          content="Stripe Issuing and Treasury platform demo"
-        />
+        <meta name="twitter:title" content="Stripe BaaS platform demo" />
         <meta
           name="twitter:description"
-          content="This web app demonstrates Stripe Issuing and Treasury APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
+          content="This web app demonstrates Stripe Banking-as-a-Service APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
         />
         <meta
           name="twitter:image"
@@ -77,7 +71,7 @@ export default function App({
         />
         <meta
           name="twitter:image:alt"
-          content="Stripe Issuing and Treasury Platform Sample App Screenshot"
+          content="Stripe BaaS platform Sample App Screenshot"
         />
       </Head>
       <SessionProvider session={session}>

--- a/embedded-finance/src/layouts/dashboard/layout.tsx
+++ b/embedded-finance/src/layouts/dashboard/layout.tsx
@@ -46,7 +46,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <>
       <Head>
-        <title>BaaS Platform Demo</title>
+        <title>Stripe BaaS platform demo</title>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
       <TopNav onNavOpen={() => setOpenNav(true)} />
@@ -57,11 +57,10 @@ const Layout = ({ children }: { children: ReactNode }) => {
           <Box px={3} py={5} sx={{ backgroundColor: "neutral.50" }}>
             <Box mx="auto" maxWidth={800} textAlign="center">
               <Typography variant="body2" color="neutral.400">
-                Stripe Issuing and Treasury Platform Demo partners with Stripe
-                Payments Company for money transmission services and account
-                services with funds held at Example Bank, Member FDIC. Stripe
-                Issuing and Treasury Platform Demo Visa® Commercial Credit
-                cards are issued by Example Bank.{" "}
+                Stripe BaaS platform demo partners with Stripe Payments Company
+                for money transmission services and account services with funds
+                held at Example Bank, Member FDIC. Stripe BaaS Platform Demo
+                Visa® Commercial Credit cards are issued by Example Bank.{" "}
                 <Link
                   href="https://stripe.com/privacy"
                   target="_blank"

--- a/embedded-finance/src/layouts/dashboard/side-nav.tsx
+++ b/embedded-finance/src/layouts/dashboard/side-nav.tsx
@@ -99,14 +99,9 @@ export const SideNav = (props: { onClose: () => void; open: boolean }) => {
           }}
           textAlign="center"
         >
-          <>
-            <Typography color="neutral.100" variant="subtitle2">
-              Stripe Issuing and Treasury
-            </Typography>
-            <Typography color="neutral.100" variant="subtitle2">
-              platform demo
-            </Typography>
-          </>
+          <Typography color="neutral.100" variant="subtitle2">
+            Stripe BaaS platform demo
+          </Typography>
           <Typography color="neutral.600" variant="subtitle2">
             Data, financial activity and cards are fictitious and for testing
             purposes only. You should not input personal information.

--- a/embedded-finance/src/pages/_app.tsx
+++ b/embedded-finance/src/pages/_app.tsx
@@ -38,20 +38,17 @@ export default function App({
   return (
     <CacheProvider value={emotionCache}>
       <Head>
-        <title>Stripe Issuing and Treasury platform demo</title>
+        <title>Stripe BaaS platform demo</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://baas.stripe.dev" />
-        <meta
-          property="og:title"
-          content="Stripe Issuing and Treasury platform demo"
-        />
+        <meta property="og:title" content="Stripe BaaS platform demo" />
         <meta
           property="og:description"
-          content="This web app demonstrates Stripe Issuing and Treasury APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
+          content="This web app demonstrates Stripe Banking-as-a-Service APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
         />
         <meta
           property="og:image"
@@ -59,17 +56,14 @@ export default function App({
         />
         <meta
           property="og:image:alt"
-          content="Stripe Issuing and Treasury Platform Sample App Screenshot"
+          content="Stripe BaaS platform Sample App Screenshot"
         />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:url" content="https://baas.stripe.dev" />
-        <meta
-          name="twitter:title"
-          content="Stripe Issuing and Treasury platform demo"
-        />
+        <meta name="twitter:title" content="Stripe BaaS platform demo" />
         <meta
           name="twitter:description"
-          content="This web app demonstrates Stripe Issuing and Treasury APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
+          content="This web app demonstrates Stripe Banking-as-a-Service APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
         />
         <meta
           name="twitter:image"
@@ -77,7 +71,7 @@ export default function App({
         />
         <meta
           name="twitter:image:alt"
-          content="Stripe Issuing and Treasury Platform Sample App Screenshot"
+          content="Stripe BaaS platform Sample App Screenshot"
         />
       </Head>
       <SessionProvider session={session}>

--- a/expense-management/src/layouts/dashboard/layout.tsx
+++ b/expense-management/src/layouts/dashboard/layout.tsx
@@ -46,7 +46,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <>
       <Head>
-        <title>BaaS Platform Demo</title>
+        <title>Stripe BaaS platform demo</title>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
       <TopNav onNavOpen={() => setOpenNav(true)} />
@@ -57,10 +57,10 @@ const Layout = ({ children }: { children: ReactNode }) => {
           <Box px={3} py={5} sx={{ backgroundColor: "neutral.50" }}>
             <Box mx="auto" maxWidth={800} textAlign="center">
               <Typography variant="body2" color="neutral.400">
-                Stripe Issuing Platform Demo partners with Stripe Payments
-                Company for money transmission services and account services.
-                Stripe Issuing Platform Demo Visa® Commercial Credit cards are
-                issued by Example Bank.{" "}
+                Stripe BaaS platform demo partners with Stripe Payments Company
+                for money transmission services and account services. Stripe
+                BaaS platform demo Visa® Commercial Credit cards are issued by
+                Example Bank.{" "}
                 <Link
                   href="https://stripe.com/privacy"
                   target="_blank"

--- a/expense-management/src/layouts/dashboard/side-nav.tsx
+++ b/expense-management/src/layouts/dashboard/side-nav.tsx
@@ -100,7 +100,7 @@ export const SideNav = (props: { onClose: () => void; open: boolean }) => {
           textAlign="center"
         >
           <Typography color="neutral.100" variant="subtitle2">
-            Stripe Issuing platform demo
+            Stripe BaaS platform demo
           </Typography>
           <Typography color="neutral.600" variant="subtitle2">
             Data, financial activity and cards are fictitious and for testing

--- a/expense-management/src/pages/_app.tsx
+++ b/expense-management/src/pages/_app.tsx
@@ -38,20 +38,17 @@ export default function App({
   return (
     <CacheProvider value={emotionCache}>
       <Head>
-        <title>Stripe Issuing and Treasury platform demo</title>
+        <title>Stripe BaaS platform demo</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://baas.stripe.dev" />
-        <meta
-          property="og:title"
-          content="Stripe Issuing and Treasury platform demo"
-        />
+        <meta property="og:title" content="Stripe BaaS platform demo" />
         <meta
           property="og:description"
-          content="This web app demonstrates Stripe Issuing and Treasury APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
+          content="This web app demonstrates Stripe Banking-as-a-Service APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
         />
         <meta
           property="og:image"
@@ -59,17 +56,14 @@ export default function App({
         />
         <meta
           property="og:image:alt"
-          content="Stripe Issuing and Treasury Platform Sample App Screenshot"
+          content="Stripe BaaS platform Sample App Screenshot"
         />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:url" content="https://baas.stripe.dev" />
-        <meta
-          name="twitter:title"
-          content="Stripe Issuing and Treasury platform demo"
-        />
+        <meta name="twitter:title" content="Stripe BaaS platform demo" />
         <meta
           name="twitter:description"
-          content="This web app demonstrates Stripe Issuing and Treasury APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
+          content="This web app demonstrates Stripe Banking-as-a-Service APIs in an end-to-end integration. Create an account with the demo platform to create cards, test purchases, and make and receive payments with a financial account."
         />
         <meta
           name="twitter:image"
@@ -77,7 +71,7 @@ export default function App({
         />
         <meta
           name="twitter:image:alt"
-          content="Stripe Issuing and Treasury Platform Sample App Screenshot"
+          content="Stripe BaaS platform Sample App Screenshot"
         />
       </Head>
       <SessionProvider session={session}>


### PR DESCRIPTION
- Renames references to the sample app to "Stripe BaaS platform demo" for consistency