### PR TITLE
Expand fake address generation to use localized faker

### DIFF
--- a/_base/src/utils/demo-helpers.ts
+++ b/_base/src/utils/demo-helpers.ts
@@ -1,4 +1,27 @@
-import { faker } from "@faker-js/faker";
+import {
+  Faker,
+  // @if financialProduct==expense-management
+  faker,
+  fakerDE_AT,
+  fakerFR_BE,
+  fakerEL,
+  fakerDE,
+  fakerES,
+  fakerFI,
+  fakerFR,
+  fakerHR,
+  fakerEN_IE,
+  fakerIT,
+  fakerLV,
+  fakerNL,
+  fakerPT_PT,
+  fakerSK,
+  fakerEN_GB,
+  // @endif
+  // @if financialProduct==embedded-finance
+  fakerEN_US,
+  // @endif
+} from "@faker-js/faker";
 
 import { SupportedCountry } from "./account-management-helpers";
 
@@ -13,6 +36,35 @@ export const isDemoMode = () => {
 
 export const TOS_ACCEPTANCE = { date: 1691518261, ip: "127.0.0.1" };
 
+const localizedFakerMap: Record<SupportedCountry, unknown> = {
+  // @if financialProduct==expense-management
+  [SupportedCountry.AT]: fakerDE_AT,
+  [SupportedCountry.BE]: fakerFR_BE,
+  [SupportedCountry.CY]: fakerEL,
+  [SupportedCountry.DE]: fakerDE,
+  [SupportedCountry.EE]: faker,
+  [SupportedCountry.ES]: fakerES,
+  [SupportedCountry.FI]: fakerFI,
+  [SupportedCountry.FR]: fakerFR,
+  [SupportedCountry.GR]: fakerEL,
+  [SupportedCountry.HR]: fakerHR,
+  [SupportedCountry.IE]: fakerEN_IE,
+  [SupportedCountry.IT]: fakerIT,
+  [SupportedCountry.LT]: faker,
+  [SupportedCountry.LU]: faker,
+  [SupportedCountry.LV]: fakerLV,
+  [SupportedCountry.MT]: faker,
+  [SupportedCountry.NL]: fakerNL,
+  [SupportedCountry.PT]: fakerPT_PT,
+  [SupportedCountry.SI]: faker,
+  [SupportedCountry.SK]: fakerSK,
+  [SupportedCountry.UK]: fakerEN_GB,
+  // @endif
+  // @if financialProduct==embedded-finance
+  [SupportedCountry.US]: fakerEN_US,
+  // @endif
+};
+
 type FakeAddress = {
   address1: string;
   city: string;
@@ -23,16 +75,9 @@ type FakeAddress = {
 export const getFakeAddressByCountry = (
   country: SupportedCountry,
 ): FakeAddress => {
+  const faker = localizedFakerMap[country] as Faker;
+
   switch (country) {
-    // @if financialProduct==embedded-finance
-    case SupportedCountry.US:
-      return {
-        address1: faker.location.streetAddress(),
-        city: faker.location.city(),
-        state: faker.location.state(),
-        zipCode: faker.location.zipCode("#####"),
-      };
-    // @endif
     // @if financialProduct==expense-management
     case SupportedCountry.UK:
       return {
@@ -42,7 +87,18 @@ export const getFakeAddressByCountry = (
         zipCode: faker.location.zipCode(),
       };
     // @endif
+    // @if financialProduct==embedded-finance
+    case SupportedCountry.US:
+      return {
+        address1: faker.location.streetAddress(),
+        city: faker.location.city(),
+        state: faker.location.state(),
+        zipCode: faker.location.zipCode("#####"),
+      };
+    // @endif
     default:
-      throw new Error(`Unsupported country: ${country}`);
+      throw new Error(
+        `Fake address generation not implemented for country: ${country}`,
+      );
   }
 };

--- a/embedded-finance/src/utils/demo-helpers.ts
+++ b/embedded-finance/src/utils/demo-helpers.ts
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import { Faker, fakerEN_US } from "@faker-js/faker";
 
 import { SupportedCountry } from "./account-management-helpers";
 
@@ -13,6 +13,10 @@ export const isDemoMode = () => {
 
 export const TOS_ACCEPTANCE = { date: 1691518261, ip: "127.0.0.1" };
 
+const localizedFakerMap: Record<SupportedCountry, unknown> = {
+  [SupportedCountry.US]: fakerEN_US,
+};
+
 type FakeAddress = {
   address1: string;
   city: string;
@@ -23,6 +27,8 @@ type FakeAddress = {
 export const getFakeAddressByCountry = (
   country: SupportedCountry,
 ): FakeAddress => {
+  const faker = localizedFakerMap[country] as Faker;
+
   switch (country) {
     case SupportedCountry.US:
       return {
@@ -32,6 +38,8 @@ export const getFakeAddressByCountry = (
         zipCode: faker.location.zipCode("#####"),
       };
     default:
-      throw new Error(`Unsupported country: ${country}`);
+      throw new Error(
+        `Fake address generation not implemented for country: ${country}`,
+      );
   }
 };

--- a/expense-management/src/utils/demo-helpers.ts
+++ b/expense-management/src/utils/demo-helpers.ts
@@ -1,4 +1,22 @@
-import { faker } from "@faker-js/faker";
+import {
+  Faker,
+  faker,
+  fakerDE_AT,
+  fakerFR_BE,
+  fakerEL,
+  fakerDE,
+  fakerES,
+  fakerFI,
+  fakerFR,
+  fakerHR,
+  fakerEN_IE,
+  fakerIT,
+  fakerLV,
+  fakerNL,
+  fakerPT_PT,
+  fakerSK,
+  fakerEN_GB,
+} from "@faker-js/faker";
 
 import { SupportedCountry } from "./account-management-helpers";
 
@@ -13,6 +31,30 @@ export const isDemoMode = () => {
 
 export const TOS_ACCEPTANCE = { date: 1691518261, ip: "127.0.0.1" };
 
+const localizedFakerMap: Record<SupportedCountry, unknown> = {
+  [SupportedCountry.AT]: fakerDE_AT,
+  [SupportedCountry.BE]: fakerFR_BE,
+  [SupportedCountry.CY]: fakerEL,
+  [SupportedCountry.DE]: fakerDE,
+  [SupportedCountry.EE]: faker,
+  [SupportedCountry.ES]: fakerES,
+  [SupportedCountry.FI]: fakerFI,
+  [SupportedCountry.FR]: fakerFR,
+  [SupportedCountry.GR]: fakerEL,
+  [SupportedCountry.HR]: fakerHR,
+  [SupportedCountry.IE]: fakerEN_IE,
+  [SupportedCountry.IT]: fakerIT,
+  [SupportedCountry.LT]: faker,
+  [SupportedCountry.LU]: faker,
+  [SupportedCountry.LV]: fakerLV,
+  [SupportedCountry.MT]: faker,
+  [SupportedCountry.NL]: fakerNL,
+  [SupportedCountry.PT]: fakerPT_PT,
+  [SupportedCountry.SI]: faker,
+  [SupportedCountry.SK]: fakerSK,
+  [SupportedCountry.UK]: fakerEN_GB,
+};
+
 type FakeAddress = {
   address1: string;
   city: string;
@@ -23,6 +65,8 @@ type FakeAddress = {
 export const getFakeAddressByCountry = (
   country: SupportedCountry,
 ): FakeAddress => {
+  const faker = localizedFakerMap[country] as Faker;
+
   switch (country) {
     case SupportedCountry.UK:
       return {
@@ -32,6 +76,8 @@ export const getFakeAddressByCountry = (
         zipCode: faker.location.zipCode(),
       };
     default:
-      throw new Error(`Unsupported country: ${country}`);
+      throw new Error(
+        `Fake address generation not implemented for country: ${country}`,
+      );
   }
 };


### PR DESCRIPTION
- Expands the fake address generation for demo purposes to use a localized faker instance whenever possible
  - There are some countries that don't have a localized faker instance. Next step would be to make sure we hard-code some demo values if they are problematic with frontend/backend validation for these countries.