### PR TITLE
Revert back to using actual testmode valid phone number

### DIFF
--- a/_base/src/pages/api/onboard.ts
+++ b/_base/src/pages/api/onboard.ts
@@ -111,10 +111,8 @@ const onboard = async (req: NextApiRequest, res: NextApiResponse) => {
         email: email,
         first_name: "John",
         last_name: "Smith",
-        // Fake phone number: https://stripe.com/docs/connect/testing
-        // TODO: Normally 000-000-0000 is a valid testmode phone number, but it's currently broken. Once Stripe fixes
-        // it, we can change back to 000-000-0000. For now, this is a fake number that will pass validation.
-        phone: "2015550123",
+        // Fake phone number: https://docs.stripe.com/connect/testing#using-oauth
+        phone: "000-000-0000",
       },
       ...(skipOnboarding && { tos_acceptance: TOS_ACCEPTANCE }),
       // Faking Terms of Service acceptances

--- a/embedded-finance/src/pages/api/onboard.ts
+++ b/embedded-finance/src/pages/api/onboard.ts
@@ -95,10 +95,8 @@ const onboard = async (req: NextApiRequest, res: NextApiResponse) => {
         email: email,
         first_name: "John",
         last_name: "Smith",
-        // Fake phone number: https://stripe.com/docs/connect/testing
-        // TODO: Normally 000-000-0000 is a valid testmode phone number, but it's currently broken. Once Stripe fixes
-        // it, we can change back to 000-000-0000. For now, this is a fake number that will pass validation.
-        phone: "2015550123",
+        // Fake phone number: https://docs.stripe.com/connect/testing#using-oauth
+        phone: "000-000-0000",
       },
       ...(skipOnboarding && { tos_acceptance: TOS_ACCEPTANCE }),
       // Faking Terms of Service acceptances

--- a/expense-management/src/pages/api/onboard.ts
+++ b/expense-management/src/pages/api/onboard.ts
@@ -94,10 +94,8 @@ const onboard = async (req: NextApiRequest, res: NextApiResponse) => {
         email: email,
         first_name: "John",
         last_name: "Smith",
-        // Fake phone number: https://stripe.com/docs/connect/testing
-        // TODO: Normally 000-000-0000 is a valid testmode phone number, but it's currently broken. Once Stripe fixes
-        // it, we can change back to 000-000-0000. For now, this is a fake number that will pass validation.
-        phone: "2015550123",
+        // Fake phone number: https://docs.stripe.com/connect/testing#using-oauth
+        phone: "000-000-0000",
       },
       ...(skipOnboarding && { tos_acceptance: TOS_ACCEPTANCE }),
       // Faking Terms of Service acceptances


### PR DESCRIPTION
- Reverts back to using actual testmode valid phone number. We had to temporarily use some other number to get through because there was a defect on Stripe's test values