### PR TITLE
Add reminders about security best practices and redact secrets in logs

### DIFF
--- a/_base/src/utils/account-management-helpers.ts
+++ b/_base/src/utils/account-management-helpers.ts
@@ -245,6 +245,11 @@ const keyPresent = (key: string | undefined): boolean =>
 export const enabledPlatforms = () => {
   // @if financialProduct==embedded-finance
   const usEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     (keyPresent(process.env.STRIPE_SECRET_KEY_US) &&
       keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US)) ||
     (keyPresent(process.env.STRIPE_SECRET_KEY) &&

--- a/_base/src/utils/stripe-authentication.ts
+++ b/_base/src/utils/stripe-authentication.ts
@@ -6,6 +6,11 @@ const getStripeSecretKey = (platform: PlatformStripeAccount): string | null => {
   switch (platform) {
     // @if financialProduct==embedded-finance
     case PlatformStripeAccount.US:
+      // Don't put any keys in code. Use an environment variable (as shown
+      // here) or secrets vault to supply keys to your integration.
+      //
+      // See https://docs.stripe.com/keys-best-practices and find your
+      // keys at https://dashboard.stripe.com/apikeys.
       key = process.env.STRIPE_SECRET_KEY_US || process.env.STRIPE_SECRET_KEY;
       break;
     // @endif

--- a/_base/src/utils/stripe-loader.ts
+++ b/_base/src/utils/stripe-loader.ts
@@ -11,6 +11,11 @@ const stripeClient = (platform: PlatformStripeAccount) => {
 
   if (!stripeSecretKey) {
     throw new Error(
+      // Don't put any keys in code. Use an environment variable (as shown
+      // here) or secrets vault to supply keys to your integration.
+      //
+      // See https://docs.stripe.com/keys-best-practices and find your
+      // keys at https://dashboard.stripe.com/apikeys.
       "Cannot instantiate Stripe client. STRIPE_SECRET_KEY needs to be set in environment variables.",
     );
   }

--- a/embedded-finance/src/utils/account-management-helpers.ts
+++ b/embedded-finance/src/utils/account-management-helpers.ts
@@ -62,6 +62,11 @@ const keyPresent = (key: string | undefined): boolean =>
 
 export const enabledPlatforms = () => {
   const usEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     (keyPresent(process.env.STRIPE_SECRET_KEY_US) &&
       keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US)) ||
     (keyPresent(process.env.STRIPE_SECRET_KEY) &&

--- a/embedded-finance/src/utils/platform-stripe-account-helpers.ts
+++ b/embedded-finance/src/utils/platform-stripe-account-helpers.ts
@@ -32,6 +32,11 @@ const keyPresent = (key: string | undefined): boolean =>
 
 const enabledPlatforms = () => {
   const usEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     (keyPresent(process.env.STRIPE_SECRET_KEY_US) &&
       keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US)) ||
     (keyPresent(process.env.STRIPE_SECRET_KEY) &&

--- a/embedded-finance/src/utils/platform.ts
+++ b/embedded-finance/src/utils/platform.ts
@@ -16,6 +16,11 @@ const keyPresent = (key: string | undefined): boolean =>
 
 const enabledPlatforms = () => {
   const usEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     (keyPresent(process.env.STRIPE_SECRET_KEY_US) &&
       keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US)) ||
     (keyPresent(process.env.STRIPE_SECRET_KEY) &&

--- a/embedded-finance/src/utils/stripe-authentication.ts
+++ b/embedded-finance/src/utils/stripe-authentication.ts
@@ -5,6 +5,11 @@ const getStripeSecretKey = (platform: PlatformStripeAccount): string | null => {
 
   switch (platform) {
     case PlatformStripeAccount.US:
+      // Don't put any keys in code. Use an environment variable (as shown
+      // here) or secrets vault to supply keys to your integration.
+      //
+      // See https://docs.stripe.com/keys-best-practices and find your
+      // keys at https://dashboard.stripe.com/apikeys.
       key = process.env.STRIPE_SECRET_KEY_US || process.env.STRIPE_SECRET_KEY;
       break;
     default:

--- a/embedded-finance/src/utils/stripe-loader.ts
+++ b/embedded-finance/src/utils/stripe-loader.ts
@@ -11,6 +11,11 @@ const stripeClient = (platform: PlatformStripeAccount) => {
 
   if (!stripeSecretKey) {
     throw new Error(
+      // Don't put any keys in code. Use an environment variable (as shown
+      // here) or secrets vault to supply keys to your integration.
+      //
+      // See https://docs.stripe.com/keys-best-practices and find your
+      // keys at https://dashboard.stripe.com/apikeys.
       "Cannot instantiate Stripe client. STRIPE_SECRET_KEY needs to be set in environment variables.",
     );
   }

--- a/expense-management/src/utils/account-management-helpers.ts
+++ b/expense-management/src/utils/account-management-helpers.ts
@@ -223,6 +223,11 @@ const keyPresent = (key: string | undefined): boolean =>
 
 export const enabledPlatforms = () => {
   const ukEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     keyPresent(process.env.STRIPE_SECRET_KEY_UK) &&
     keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK);
 

--- a/expense-management/src/utils/platform-stripe-account-helpers.ts
+++ b/expense-management/src/utils/platform-stripe-account-helpers.ts
@@ -73,6 +73,11 @@ const keyPresent = (key: string | undefined): boolean =>
 
 const enabledPlatforms = () => {
   const ukEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     keyPresent(process.env.STRIPE_SECRET_KEY_UK) &&
     keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK);
 

--- a/expense-management/src/utils/platform.ts
+++ b/expense-management/src/utils/platform.ts
@@ -19,6 +19,11 @@ const keyPresent = (key: string | undefined): boolean =>
 
 const enabledPlatforms = () => {
   const ukEnabled =
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     keyPresent(process.env.STRIPE_SECRET_KEY_UK) &&
     keyPresent(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK);
 

--- a/expense-management/src/utils/stripe-authentication.ts
+++ b/expense-management/src/utils/stripe-authentication.ts
@@ -5,6 +5,11 @@ const getStripeSecretKey = (platform: PlatformStripeAccount): string | null => {
 
   switch (platform) {
     case PlatformStripeAccount.UK:
+      // Don't put any keys in code. Use an environment variable (as shown
+      // here) or secrets vault to supply keys to your integration.
+      //
+      // See https://docs.stripe.com/keys-best-practices and find your
+      // keys at https://dashboard.stripe.com/apikeys.
       key = process.env.STRIPE_SECRET_KEY_UK;
       break;
     case PlatformStripeAccount.EU:

--- a/expense-management/src/utils/stripe-loader.ts
+++ b/expense-management/src/utils/stripe-loader.ts
@@ -11,6 +11,11 @@ const stripeClient = (platform: PlatformStripeAccount) => {
 
   if (!stripeSecretKey) {
     throw new Error(
+      // Don't put any keys in code. Use an environment variable (as shown
+      // here) or secrets vault to supply keys to your integration.
+      //
+      // See https://docs.stripe.com/keys-best-practices and find your
+      // keys at https://dashboard.stripe.com/apikeys.
       "Cannot instantiate Stripe client. STRIPE_SECRET_KEY needs to be set in environment variables.",
     );
   }


### PR DESCRIPTION
## Summary

- Adds comments before `STRIPE_SECRET_KEY` assignments in all server files urging users not to put keys in code and pointing to [https://docs.stripe.com/keys-best-practices](https://docs.stripe.com/keys-best-practices).
