### PR TITLE
Gate card and cardholder creation on the card_issuing capability

### DIFF
--- a/_base/src/pages/api/cardholders.ts
+++ b/_base/src/pages/api/cardholders.ts
@@ -5,6 +5,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { apiResponse } from "src/types/api-response";
 import { SupportedCountry } from "src/utils/account-management-helpers";
 import { handlerMapping } from "src/utils/api-helpers";
+import { isCardIssuingActive } from "src/utils/onboarding-helpers";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 import validationSchemas from "src/utils/validation-schemas";
@@ -24,6 +25,23 @@ const createCardholder = async (req: NextApiRequest, res: NextApiResponse) => {
     // @end-exclude-from-subapps
   } = session;
   const { accountId, platform } = stripeAccount;
+
+  // The `card_issuing` capability can still be activating for a short while
+  // after onboarding completes. Creating a cardholder before it is active fails,
+  // so surface a clear message instead of letting the Stripe error surface as a
+  // 500. See https://github.com/stripe-samples/issuing-treasury/issues/380
+  if (!(await isCardIssuingActive(stripeAccount))) {
+    return res.status(400).json(
+      apiResponse({
+        success: false,
+        error: {
+          message:
+            "Your account's card issuing capability is still being activated. " +
+            "This can take a few minutes after onboarding. Please try again shortly.",
+        },
+      }),
+    );
+  }
 
   const validationSchema = (() => {
     // @begin-exclude-from-subapps

--- a/_base/src/pages/api/cards/index.ts
+++ b/_base/src/pages/api/cards/index.ts
@@ -4,6 +4,7 @@ import Stripe from "stripe";
 import { apiResponse } from "src/types/api-response";
 import FinancialProduct from "src/types/financial-product";
 import { handlerMapping } from "src/utils/api-helpers";
+import { isCardIssuingActive } from "src/utils/onboarding-helpers";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 import validationSchemas from "src/utils/validation-schemas";
@@ -24,6 +25,23 @@ const createCard = async (req: NextApiRequest, res: NextApiResponse) => {
   } = session;
   const { accountId, platform } = stripeAccount;
   const stripe = stripeClient(platform);
+
+  // The `card_issuing` capability can still be activating for a short while
+  // after onboarding completes. Issuing a card before it is active fails, so
+  // surface a clear message instead of letting the Stripe error surface as a
+  // 500. See https://github.com/stripe-samples/issuing-treasury/issues/380
+  if (!(await isCardIssuingActive(stripeAccount))) {
+    return res.status(400).json(
+      apiResponse({
+        success: false,
+        error: {
+          message:
+            "Your account's card issuing capability is still being activated. " +
+            "This can take a few minutes after onboarding. Please try again shortly.",
+        },
+      }),
+    );
+  }
 
   // @if financialProduct==embedded-finance
   const financialAccount = await (async () => {

--- a/_base/src/utils/onboarding-helpers.ts
+++ b/_base/src/utils/onboarding-helpers.ts
@@ -23,6 +23,20 @@ export const hasOutstandingRequirements = async (
   return result;
 };
 
+// After onboarding completes, the `card_issuing` capability is not necessarily
+// active right away: activation can take a couple of minutes. Issuing a card or
+// creating a cardholder before it becomes `active` fails, so callers should
+// gate those actions on this check.
+export const isCardIssuingActive = async (
+  stripeAccount: StripeAccount,
+): Promise<boolean> => {
+  const { accountId, platform } = stripeAccount;
+  const stripe = stripeClient(platform);
+  const account = await stripe.accounts.retrieve(accountId);
+
+  return account.capabilities?.card_issuing === "active";
+};
+
 export async function createAccountOnboardingUrl(stripeAccount: StripeAccount) {
   if (
     process.env.CONNECT_ONBOARDING_REDIRECT_URL == undefined &&

--- a/embedded-finance/src/pages/api/cardholders.ts
+++ b/embedded-finance/src/pages/api/cardholders.ts
@@ -4,6 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { apiResponse } from "src/types/api-response";
 import { handlerMapping } from "src/utils/api-helpers";
+import { isCardIssuingActive } from "src/utils/onboarding-helpers";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 import validationSchemas from "src/utils/validation-schemas";
@@ -18,6 +19,23 @@ const createCardholder = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSessionForServerSide(req, res);
   const { stripeAccount } = session;
   const { accountId, platform } = stripeAccount;
+
+  // The `card_issuing` capability can still be activating for a short while
+  // after onboarding completes. Creating a cardholder before it is active fails,
+  // so surface a clear message instead of letting the Stripe error surface as a
+  // 500. See https://github.com/stripe-samples/issuing-treasury/issues/380
+  if (!(await isCardIssuingActive(stripeAccount))) {
+    return res.status(400).json(
+      apiResponse({
+        success: false,
+        error: {
+          message:
+            "Your account's card issuing capability is still being activated. " +
+            "This can take a few minutes after onboarding. Please try again shortly.",
+        },
+      }),
+    );
+  }
 
   const validationSchema = (() => {
     return validationSchemas.cardholder.default;

--- a/embedded-finance/src/pages/api/cards/index.ts
+++ b/embedded-finance/src/pages/api/cards/index.ts
@@ -3,6 +3,7 @@ import Stripe from "stripe";
 
 import { apiResponse } from "src/types/api-response";
 import { handlerMapping } from "src/utils/api-helpers";
+import { isCardIssuingActive } from "src/utils/onboarding-helpers";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 import validationSchemas from "src/utils/validation-schemas";
@@ -17,6 +18,23 @@ const createCard = async (req: NextApiRequest, res: NextApiResponse) => {
   const { stripeAccount, currency } = session;
   const { accountId, platform } = stripeAccount;
   const stripe = stripeClient(platform);
+
+  // The `card_issuing` capability can still be activating for a short while
+  // after onboarding completes. Issuing a card before it is active fails, so
+  // surface a clear message instead of letting the Stripe error surface as a
+  // 500. See https://github.com/stripe-samples/issuing-treasury/issues/380
+  if (!(await isCardIssuingActive(stripeAccount))) {
+    return res.status(400).json(
+      apiResponse({
+        success: false,
+        error: {
+          message:
+            "Your account's card issuing capability is still being activated. " +
+            "This can take a few minutes after onboarding. Please try again shortly.",
+        },
+      }),
+    );
+  }
 
   const financialAccount = await (async () => {
     const financialAccounts = await stripe.treasury.financialAccounts.list({

--- a/embedded-finance/src/utils/onboarding-helpers.ts
+++ b/embedded-finance/src/utils/onboarding-helpers.ts
@@ -23,6 +23,20 @@ export const hasOutstandingRequirements = async (
   return result;
 };
 
+// After onboarding completes, the `card_issuing` capability is not necessarily
+// active right away: activation can take a couple of minutes. Issuing a card or
+// creating a cardholder before it becomes `active` fails, so callers should
+// gate those actions on this check.
+export const isCardIssuingActive = async (
+  stripeAccount: StripeAccount,
+): Promise<boolean> => {
+  const { accountId, platform } = stripeAccount;
+  const stripe = stripeClient(platform);
+  const account = await stripe.accounts.retrieve(accountId);
+
+  return account.capabilities?.card_issuing === "active";
+};
+
 export async function createAccountOnboardingUrl(stripeAccount: StripeAccount) {
   if (
     process.env.CONNECT_ONBOARDING_REDIRECT_URL == undefined &&

--- a/expense-management/src/pages/api/cardholders.ts
+++ b/expense-management/src/pages/api/cardholders.ts
@@ -4,6 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { apiResponse } from "src/types/api-response";
 import { handlerMapping } from "src/utils/api-helpers";
+import { isCardIssuingActive } from "src/utils/onboarding-helpers";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 import validationSchemas from "src/utils/validation-schemas";
@@ -18,6 +19,23 @@ const createCardholder = async (req: NextApiRequest, res: NextApiResponse) => {
   const session = await getSessionForServerSide(req, res);
   const { stripeAccount } = session;
   const { accountId, platform } = stripeAccount;
+
+  // The `card_issuing` capability can still be activating for a short while
+  // after onboarding completes. Creating a cardholder before it is active fails,
+  // so surface a clear message instead of letting the Stripe error surface as a
+  // 500. See https://github.com/stripe-samples/issuing-treasury/issues/380
+  if (!(await isCardIssuingActive(stripeAccount))) {
+    return res.status(400).json(
+      apiResponse({
+        success: false,
+        error: {
+          message:
+            "Your account's card issuing capability is still being activated. " +
+            "This can take a few minutes after onboarding. Please try again shortly.",
+        },
+      }),
+    );
+  }
 
   const validationSchema = (() => {
     // PSD2 requires most transactions on payment cards issued in the EU and UK

--- a/expense-management/src/pages/api/cards/index.ts
+++ b/expense-management/src/pages/api/cards/index.ts
@@ -3,6 +3,7 @@ import Stripe from "stripe";
 
 import { apiResponse } from "src/types/api-response";
 import { handlerMapping } from "src/utils/api-helpers";
+import { isCardIssuingActive } from "src/utils/onboarding-helpers";
 import { getSessionForServerSide } from "src/utils/session-helpers";
 import stripeClient from "src/utils/stripe-loader";
 import validationSchemas from "src/utils/validation-schemas";
@@ -17,6 +18,23 @@ const createCard = async (req: NextApiRequest, res: NextApiResponse) => {
   const { stripeAccount, currency } = session;
   const { accountId, platform } = stripeAccount;
   const stripe = stripeClient(platform);
+
+  // The `card_issuing` capability can still be activating for a short while
+  // after onboarding completes. Issuing a card before it is active fails, so
+  // surface a clear message instead of letting the Stripe error surface as a
+  // 500. See https://github.com/stripe-samples/issuing-treasury/issues/380
+  if (!(await isCardIssuingActive(stripeAccount))) {
+    return res.status(400).json(
+      apiResponse({
+        success: false,
+        error: {
+          message:
+            "Your account's card issuing capability is still being activated. " +
+            "This can take a few minutes after onboarding. Please try again shortly.",
+        },
+      }),
+    );
+  }
 
   const { cardholderid, card_type } = req.body;
   const cardholder = await stripe.issuing.cardholders.retrieve(cardholderid, {

--- a/expense-management/src/utils/onboarding-helpers.ts
+++ b/expense-management/src/utils/onboarding-helpers.ts
@@ -23,6 +23,20 @@ export const hasOutstandingRequirements = async (
   return result;
 };
 
+// After onboarding completes, the `card_issuing` capability is not necessarily
+// active right away: activation can take a couple of minutes. Issuing a card or
+// creating a cardholder before it becomes `active` fails, so callers should
+// gate those actions on this check.
+export const isCardIssuingActive = async (
+  stripeAccount: StripeAccount,
+): Promise<boolean> => {
+  const { accountId, platform } = stripeAccount;
+  const stripe = stripeClient(platform);
+  const account = await stripe.accounts.retrieve(accountId);
+
+  return account.capabilities?.card_issuing === "active";
+};
+
 export async function createAccountOnboardingUrl(stripeAccount: StripeAccount) {
   if (
     process.env.CONNECT_ONBOARDING_REDIRECT_URL == undefined &&


### PR DESCRIPTION
## What

Fixes #380.

After Connect onboarding completes, the `card_issuing` capability can stay `pending` for a short while (activation currently takes ~2 minutes). Creating a card or cardholder during that window throws a Stripe error that today surfaces as a raw **HTTP 500**.

This gates `createCard` and `createCardholder` on the capability being active and returns a clear message while it is still activating.

## Changes

- **`src/utils/onboarding-helpers.ts`** — new `isCardIssuingActive(stripeAccount)` that reads `account.capabilities?.card_issuing === "active"`. It mirrors the existing `hasOutstandingRequirements` helper in the same file (same `accounts.retrieve` + inspect pattern).
- **`src/pages/api/cardholders.ts`** and **`src/pages/api/cards/index.ts`** — a guard at the top of the create handlers that returns a `400` `apiResponse({ success: false, error })` when the capability is not yet active, instead of proceeding to the Stripe call.

## Behavior per entry point

- **Cardholder creation** is an AJAX call (`cardholder-create-widget.tsx` → `postApi` / `handleResult`), so the message renders in the existing `<Alert>` — no UI change needed.
- **Card issuance** ("Issue card" in `cardholders-table.tsx`) is a native `<form method="POST">`, so the `400` is returned as a JSON body — the same shape and behavior as this endpoint's existing validation-error branch in `cards/index.ts`. Giving that form a nicer in-app error (a redirect with a query param, or an AJAX submit like the cardholder widget) would be a reasonable follow-up but is out of scope for #380.

> Aside: the reason the underlying Stripe error surfaces as a generic 500 today is that `handlerMapping` returns the async handler without `await`, so rejections escape its `try/catch`. This guard returns *before* the Stripe call, so it is unaffected; hardening `handlerMapping` more broadly is intentionally left out of scope here.

## Note on codegen

`_base` is the source of truth and was edited normally. I also updated the two generated apps (`embedded-finance`, `expense-management`) by hand with the **byte-identical** guard rather than running `./codegen.sh`, because a full regen currently surfaces unrelated pre-existing drift (e.g. the Stripe `apiVersion`, formatting) as many extra changed files. Happy to regenerate instead if you'd prefer.

## Testing

- `_base` builds green: `npm run build` (compile, lint, and type-check all pass).
- Manual: with a freshly-onboarded connected account, creating a cardholder/card within the first ~2 minutes now returns the "still being activated" message instead of a 500; once `card_issuing` is `active`, creation proceeds as before.
